### PR TITLE
인증 페이지 레이아웃 및 로고 추가

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -5,7 +5,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen px-8 overflow-hidden bg-white">
       <Link href="/" className="mb-2">
-        <Image width={200} height={200} src="/GilaLogo.png" alt="logo-to-home" />
+        <Image width={180} height={180} src="/GilaLogo.png" alt="logo-to-home" />
       </Link>
       <main className="w-[450px] px-10">{children}</main>
     </div>

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -4,8 +4,8 @@ import Link from 'next/link';
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen px-8 overflow-hidden bg-white">
-      <Link href="/">
-        <Image width={250} height={250} src="/GilaName.png" alt="logo-to-home" />
+      <Link href="/" className="mb-2">
+        <Image width={200} height={200} src="/GilaLogo.png" alt="logo-to-home" />
       </Link>
       <main className="w-[450px] px-10">{children}</main>
     </div>

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,7 +1,13 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <main className="min-h-screen bg-stone-200 flex items-center justify-center">
-      <div className="w-[450px]">{children}</div>
-    </main>
+    <div className="flex flex-col items-center justify-center min-h-screen px-8 overflow-hidden bg-white">
+      <Link href="/">
+        <Image width={250} height={250} src="/GilaName.png" alt="logo-to-home" />
+      </Link>
+      <main className="w-[450px] px-10">{children}</main>
+    </div>
   );
 }

--- a/app/(auth)/sign-in/_components/login-form.tsx
+++ b/app/(auth)/sign-in/_components/login-form.tsx
@@ -22,11 +22,11 @@ import { useRouter } from 'next/navigation';
 import PasswordInput from '@/components/ui/password-input';
 
 const loginFields = [
-  { name: 'email', label: 'Email', placeholder: 'test@test.com', type: 'text' },
+  { name: 'email', label: '이메일', placeholder: '이메일을 입력해 주세요', type: 'text' },
   {
     name: 'password',
-    label: 'Password',
-    placeholder: '********',
+    label: '비밀번호',
+    placeholder: '비밀번호를 입력해 주세요',
     type: 'password',
   },
 ];
@@ -43,6 +43,7 @@ export default function LoginForm() {
       email: '',
       password: '',
     },
+    mode: 'onBlur',
   });
 
   const handleVisibility = () => {
@@ -78,10 +79,16 @@ export default function LoginForm() {
                       type={isVisible ? 'text' : 'password'}
                       handleToggle={handleVisibility}
                       placeholder={field.placeholder}
+                      className="border-none shadow-md"
                       {...controllerField}
                     />
                   ) : (
-                    <Input type={field.type} placeholder={field.placeholder} {...controllerField} />
+                    <Input
+                      type={field.type}
+                      placeholder={field.placeholder}
+                      className="border-none shadow-md"
+                      {...controllerField}
+                    />
                   )}
                 </FormControl>
                 <div className="h-5">
@@ -91,7 +98,11 @@ export default function LoginForm() {
             )}
           />
         ))}
-        <Button disabled={isPending} type="submit" className="w-full">
+        <Button
+          disabled={isPending}
+          type="submit"
+          className="w-full py-3 text-base font-semibold shadow-lg hover:bg-primary_dark active:bg-primary_dark"
+        >
           로그인
         </Button>
       </form>

--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -3,13 +3,15 @@ import LoginForm from './_components/login-form';
 
 export default function Page() {
   return (
-    <div className="space-y-5 p-4">
+    <div className="p-4 space-y-5">
       <LoginForm />
-      <div className="mt-2 flex items-center justify-center gap-x-2">
-        <p className="font-semibold">회원이 아니신가요?</p>
-        <Link href="/sign-up" className="text-blue-600 underline">
-          회원가입하기
-        </Link>
+      <div className="flex items-center justify-center mt-2 gap-x-2">
+        <p className="text-gray-500">
+          길라가 처음인가요?{' '}
+          <Link href="/sign-up" className="font-semibold underline text-primary">
+            회원가입하기
+          </Link>
+        </p>
       </div>
     </div>
   );

--- a/app/(auth)/sign-up/_components/register-form.tsx
+++ b/app/(auth)/sign-up/_components/register-form.tsx
@@ -21,19 +21,19 @@ import { toast } from 'sonner';
 import { useRouter } from 'next/navigation';
 import PasswordInput from '@/components/ui/password-input';
 
-const fields = [
-  { name: 'nickname', label: 'Nickname', placeholder: 'kkkk', type: 'text' },
-  { name: 'email', label: 'Email', placeholder: 'test@test.com', type: 'text' },
+const registerFields = [
+  { name: 'nickname', label: '닉네임', placeholder: '닉네임을 입력해 주세요', type: 'text' },
+  { name: 'email', label: '이메일', placeholder: '이메일을 입력해 주세요', type: 'text' },
   {
     name: 'password',
-    label: 'Password',
-    placeholder: '********',
+    label: '비밀번호',
+    placeholder: '비밀번호를 입력해 주세요',
     type: 'password',
   },
   {
     name: 'confirmPassword',
-    label: 'Confirm Password',
-    placeholder: '********',
+    label: '비밀번호 확인',
+    placeholder: '비밀번호를 한 번 더 입력해 주세요',
     type: 'password',
   },
 ];
@@ -48,10 +48,12 @@ export default function RegisterForm() {
   const form = useForm<RegisterSchemaType>({
     resolver: zodResolver(RegisterSchema),
     defaultValues: {
+      nickname: '',
       email: '',
       password: '',
       confirmPassword: '',
     },
+    mode: 'onBlur',
   });
 
   function onSubmit(values: RegisterSchemaType) {
@@ -82,7 +84,7 @@ export default function RegisterForm() {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="w-full">
-        {fields.map((field) => (
+        {registerFields.map((field) => (
           <FormField
             key={field.name}
             control={form.control}
@@ -96,10 +98,16 @@ export default function RegisterForm() {
                       type={settingPasswordInputType(field.name) ? 'text' : 'password'}
                       handleToggle={() => handleVisibility(field.name)}
                       placeholder={field.placeholder}
+                      className="border-none shadow-md"
                       {...controllerField}
                     />
                   ) : (
-                    <Input type={field.type} placeholder={field.placeholder} {...controllerField} />
+                    <Input
+                      type={field.type}
+                      placeholder={field.placeholder}
+                      className="border-none shadow-md"
+                      {...controllerField}
+                    />
                   )}
                 </FormControl>
                 <div className="h-5">
@@ -109,7 +117,11 @@ export default function RegisterForm() {
             )}
           />
         ))}
-        <Button disabled={isPending} type="submit" className="w-full">
+        <Button
+          disabled={isPending}
+          type="submit"
+          className="w-full py-3 text-base font-semibold shadow-lg hover:bg-primary_dark active:bg-primary_dark"
+        >
           회원가입
         </Button>
       </form>

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -3,13 +3,15 @@ import RegisterForm from './_components/register-form';
 
 export default function Page() {
   return (
-    <div className="space-y-5 p-4">
+    <div className="p-4 space-y-5">
       <RegisterForm />
-      <div className="mt-2 flex items-center justify-center gap-x-2">
-        <p className="font-semibold">이미 회원이신가요?</p>
-        <Link href="/sign-in" className="text-sky-500 underline">
-          로그인하기
-        </Link>
+      <div className="flex items-center justify-center mt-2 gap-x-2">
+        <p className="text-gray-500">
+          이미 길라와 연결되셨다면?{' '}
+          <Link href="/sign-in" className="font-semibold underline text-primary">
+            로그인하기
+          </Link>
+        </p>
       </div>
     </div>
   );

--- a/components/ui/password-input.tsx
+++ b/components/ui/password-input.tsx
@@ -15,7 +15,7 @@ const PasswordInput = forwardRef<HTMLInputElement, Props>(
 
     return (
       <div className="relative">
-        <Input ref={ref} {...props} />
+        <Input className={className} ref={ref} {...props} />
         <Button
           type="button"
           variant="ghost"

--- a/constants/regex.ts
+++ b/constants/regex.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const PASSWORD_REGEX = /^(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]{8,}$/; // 대소문자 구별 없이 알파벳과 숫자 포함하여 8자 이상

--- a/schema.ts
+++ b/schema.ts
@@ -1,18 +1,26 @@
 import z from 'zod';
+import { PASSWORD_REGEX } from '@/constants/regex';
 
 export const LoginSchema = z.object({
-  email: z.string().email({ message: '올바른 이메일 형식을 입력해주세요.' }),
-  password: z.string().min(8, { message: '패스워드는 최소 8글자 이상입니다.' }),
+  email: z.string().email({ message: '올바른 이메일 형식을 입력해 주세요.' }),
+  password: z.string().regex(PASSWORD_REGEX, {
+    message: '비밀번호는 8자 이상이어야 하며, 알파벳과 숫자를 포함해야 합니다',
+  }),
 });
 
 export const RegisterSchema = z
   .object({
-    nickname: z.string().min(1).max(10),
-    email: z.string().email({ message: '올바른 이메일 형식을 입력해주세요.' }),
-    password: z.string().min(8, { message: '패스워드는 최소 8글자 이상입니다.' }),
-    confirmPassword: z.string().min(1, { message: '필드를 입력해주세요.' }),
+    nickname: z
+      .string()
+      .min(1, { message: '닉네임을 입력해 주세요' })
+      .max(10, { message: '닉네임은 최대 10글자까지 가능합니다' }),
+    email: z.string().email({ message: '올바른 이메일 형식을 입력해 주세요' }),
+    password: z.string().regex(PASSWORD_REGEX, {
+      message: '비밀번호는 8자 이상이어야 하며, 알파벳과 숫자를 포함해야 합니다',
+    }),
+    confirmPassword: z.string().min(1, { message: '비밀번호를 재입력 해주세요' }),
   })
   .refine((data) => data.password === data.confirmPassword, {
-    message: '패스워드가 일치하지 않습니다.',
+    message: '비밀번호가 일치하지 않습니다',
     path: ['confirmPassword'],
   });


### PR DESCRIPTION
팀미팅때 제안한 화면 색상 적용해보았습니다.
홈으로 이동 가능한 로고 추가해 주었고 react-hook-form 모드도 onBlur로 수정하여 바로 체크하도록 개선하였습니다.

- 수정 전
<img width="460" alt="image" src="https://github.com/user-attachments/assets/ed08e53d-72b9-450b-9724-61ffe70d3163">
<img width="460" alt="image" src="https://github.com/user-attachments/assets/e1295db9-9a2a-4fa3-b4dd-78f023dc40e1">

- 수정 후
![image](https://github.com/user-attachments/assets/d09c2bda-db22-4975-a227-f2c99aaa8900)

- 최종 수정
![image](https://github.com/user-attachments/assets/ffc7866c-be55-46e2-ac42-7b9d904de56e)

