### PR TITLE
커서아이디 초기화 삭제

### DIFF
--- a/app/(protected)/(user)/dashboard/promised-list/_components/promised-list.tsx
+++ b/app/(protected)/(user)/dashboard/promised-list/_components/promised-list.tsx
@@ -33,8 +33,7 @@ export default function PromisedList({ promisedActivities, cursorId }: Props) {
 
   useEffect(() => {
     setInfinityPromisedActivities([...promisedActivities]);
-    setInfinityCursorId(cursorId);
-  }, [cursorId, promisedActivities]);
+  }, [promisedActivities]);
 
   const observer = useInfiniteScroll({
     callback: loadMorePromisedActivities,


### PR DESCRIPTION
커서아이디가 계속 초기화되서 null이 아닌 마지막 커서아이디가 계속 들어가는 문제를 해결