### PR TITLE
drawer 로직 수정

### DIFF
--- a/components/location-select-drawer-nav.tsx
+++ b/components/location-select-drawer-nav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import {
   Command,
@@ -26,6 +26,7 @@ import { Compass } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export default function LocationSelectDrawerForNav() {
+  const [isDrawOpen, setIsDrawOpen] = useState(false);
   const [province, setProvince] = useState<string | null>(null);
   const [selectedLocation, setSelectedLocation] = useState<string | null>(null);
   const router = useRouter();
@@ -34,6 +35,16 @@ export default function LocationSelectDrawerForNav() {
   const cities = useMemo(() => {
     return province ? LOCATIONS[province] : [];
   }, [province]);
+
+  const handleSelectProvince = (provinceLocation: string) => {
+    if (provinceLocation === '세종특별자치시') {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('location', provinceLocation);
+      router.push(`?${params.toString()}`);
+    } else {
+      setProvince(provinceLocation);
+    }
+  };
 
   const handleSelectLocation = (location: string) => {
     if (province) {
@@ -59,8 +70,19 @@ export default function LocationSelectDrawerForNav() {
     router.push(`?${params.toString()}`);
   };
 
+  useEffect(() => {
+    const locationValue = searchParams.get('location');
+    if (!locationValue) {
+      setProvince(null);
+      setSelectedLocation(null);
+    } else {
+      setSelectedLocation(locationValue);
+      setIsDrawOpen(false);
+    }
+  }, [searchParams]);
+
   return (
-    <Drawer>
+    <Drawer open={isDrawOpen} onOpenChange={setIsDrawOpen}>
       <DrawerTrigger asChild>
         <Button
           type="button"
@@ -90,13 +112,7 @@ export default function LocationSelectDrawerForNav() {
                         <CommandItem
                           key={_province}
                           value={_province}
-                          onSelect={(value) => {
-                            setSelectedLocation(value);
-                            setProvince(value);
-                            const params = new URLSearchParams(searchParams.toString());
-                            params.set('location', value);
-                            router.push(`?${params.toString()}`);
-                          }}
+                          onSelect={handleSelectProvince}
                           className={cn(
                             province === _province && 'bg-gray-200',
                             'flex items-center justify-center p-2 font-medium rounded-lg shadow-md hover:bg-gray-100',


### PR DESCRIPTION
우선 searchParams으로 설정된 location이 페이지 다시 접근했을때 적용되지 않는 문제가 있어서 useEffect 적용시켜놨습니다.

추가적으로 drawer상태 state만들어서 특정 동작일때 닫히도록 만들었습니다.
1. 만약 로케이션값 변경으로 주소 이동되었을때 useEffect를 이용해 닫히도록 만들었고
2. 초기화한 경우 로케이션 값을 다시 설정하도록 유도하기 위해 draw open시켜놨습니다

그리고 세종시의 경우 세부 로케이션값이 없어서 도시만 설정해도 searchParams 이동하도록 해주신것 같은데 그러면 도시 클릭할때마다 데이터를 불러오는게 불필요하다고 생각해서 어쩔수없이 '세종특별자치시'만 걸러내는 함수로 변경시켜봤습니다. 세종시일때에만 바로 로케이션 이동하고 나머지 주소는 세부주소까지 입력해야 searchParams에 로케이션 값 들어갑니다.