### PR TITLE
대시보드 카드 스타일 수정

### DIFF
--- a/app/(protected)/(user)/dashboard/my-activity/_components/my-activity-card.tsx
+++ b/app/(protected)/(user)/dashboard/my-activity/_components/my-activity-card.tsx
@@ -6,7 +6,7 @@ import formatDateRange from '@/utils/formatDateRange';
 import { deleteActivity } from '@/app/action/activity';
 import { ActivityWithFavoriteAndCount } from '@/type';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
 import DeleteAlertModal from '@/components/delete-alert-modal';
 import ActivityEditForm from './activity-edit-form';
 
@@ -82,6 +82,7 @@ export default function MyActivityCard({ activity }: Props) {
       <Dialog open={isEditModalOpen} onOpenChange={setEditModalOpen}>
         <DialogContent className="h-screen overflow-y-auto bg-white">
           <DialogTitle className="text-2xl font-semibold">길라 활동 수정</DialogTitle>
+          <DialogDescription aria-describedby={undefined} />
           <ActivityEditForm activity={activity} onClose={() => setEditModalOpen(false)} />
         </DialogContent>
       </Dialog>

--- a/app/(protected)/(user)/dashboard/my-activity/page.tsx
+++ b/app/(protected)/(user)/dashboard/my-activity/page.tsx
@@ -22,7 +22,7 @@ export default async function Page() {
           </p>
         </div>
         <div>
-          <Link href="/dashboard/my-activity/create" className="relative z-50">
+          <Link href="/dashboard/my-activity/create" className="relative z-10">
             <PlusDiv />
           </Link>
         </div>

--- a/app/(protected)/(user)/dashboard/my-question/page.tsx
+++ b/app/(protected)/(user)/dashboard/my-question/page.tsx
@@ -5,7 +5,7 @@ import MyQuestionCreateModal from '@/app/(protected)/(user)/dashboard/my-questio
 export default async function Page() {
   const myQuestions = await getMyQuestions({ take: 10, answerTake: 5 });
   return (
-    <div className="p-5">
+    <div className="p-5 pb-20">
       <div className="flex justify-between w-full mb-5">
         <h1 className="text-2xl font-bold">내 질문</h1>
         <MyQuestionCreateModal />

--- a/app/(protected)/(user)/dashboard/promise-list/_components/promise-list-card.tsx
+++ b/app/(protected)/(user)/dashboard/promise-list/_components/promise-list-card.tsx
@@ -35,19 +35,17 @@ export default function PromiseListCard({ promise }: { promise: RequestWithActiv
           <div className="text-sm font-semibold text-gray-900">
             <p>최대 인원: {maximumCount} 명</p>
           </div>
+          <PromiseStatus status={promise.status} />
         </>
       }
       bottomContent={
-        <div className="absolute bottom-2 right-2 flex gap-32">
-          <div className="flex justify-end translate-y-[6px]">
-            <PromiseStatus status={promise.status} />
-          </div>
-          {promise.status === 'PENDING' && (
+        promise.status === 'PENDING' && (
+          <div className="absolute bottom-2 right-2 flex gap-32">
             <div className="w-[70px]" onClick={(e) => e.preventDefault()}>
               <DeleteAlertModal deleteAction={cancelPromise} isButton content="취소" />
             </div>
-          )}
-        </div>
+          </div>
+        )
       }
     />
   );

--- a/app/(protected)/(user)/dashboard/promise-list/_components/promise-status.tsx
+++ b/app/(protected)/(user)/dashboard/promise-list/_components/promise-status.tsx
@@ -16,7 +16,7 @@ export default function PromiseStatus({ status }: Props) {
   return (
     <div className={`${textColor} text-xs flex gap-2 items-center`}>
       <div className={`rounded-full w-2 h-2 ${bgColor}`} />
-      {text}
+      <p>{text}</p>
     </div>
   );
 }

--- a/app/(protected)/(user)/dashboard/promise-list/page.tsx
+++ b/app/(protected)/(user)/dashboard/promise-list/page.tsx
@@ -9,7 +9,7 @@ export default async function Page() {
   const user = await getCurrentUser();
 
   return (
-    <main className="p-5">
+    <main className="p-5 pb-20">
       <h1 className="w-full text-2xl font-bold">
         <span className="text-3xl text-primary">{user.nickname}</span>님이 신청한 활동
       </h1>

--- a/app/(protected)/(user)/dashboard/promised-list/page.tsx
+++ b/app/(protected)/(user)/dashboard/promised-list/page.tsx
@@ -9,7 +9,7 @@ export default async function Page() {
   const user = await getCurrentUser();
 
   return (
-    <main className="p-5">
+    <main className="p-5 pb-20">
       <h1 className="w-full text-2xl font-bold">
         <span className="text-3xl text-primary">{user.nickname}</span>님과 함께하고 싶데요!
       </h1>

--- a/app/(protected)/(user)/dashboard/reviews/page.tsx
+++ b/app/(protected)/(user)/dashboard/reviews/page.tsx
@@ -6,7 +6,7 @@ export default async function Page() {
   const { activities, cursorId } = activitiesRes;
 
   return (
-    <main className="p-5">
+    <main className="p-5 pb-20">
       <h1 className="text-2xl font-bold">이전 활동은 어땠나요?</h1>
       <ReviewList activities={activities} cursorId={cursorId} />
     </main>

--- a/app/(protected)/(user)/dashboard/wishlist/page.tsx
+++ b/app/(protected)/(user)/dashboard/wishlist/page.tsx
@@ -7,7 +7,7 @@ export default async function Page() {
   const { favorites, cursorId } = await getMyFavorites({ take: 10 });
 
   return (
-    <main className="p-5">
+    <main className="p-5 pb-20">
       <h1 className="text-2xl font-bold">저장한 활동</h1>
       <Suspense fallback={<Loading />}>
         <WishListContainer initialFavorites={favorites} initialCursorId={cursorId} />

--- a/components/image-card.tsx
+++ b/components/image-card.tsx
@@ -43,7 +43,7 @@ export default function ImageCard({
             <CardTitle className="text-2xl font-bold text-black truncate">{title}</CardTitle>
           </CardHeader>
           <CardContent className="p-0">{middleContent}</CardContent>
-          <CardFooter className="p-0">{bottomContent}</CardFooter>
+          {bottomContent && <CardFooter className="p-0">{bottomContent}</CardFooter>}
         </div>
         {isPending && (
           <div

--- a/components/location-select-drawer-nav.tsx
+++ b/components/location-select-drawer-nav.tsx
@@ -47,16 +47,14 @@ export default function LocationSelectDrawerForNav() {
   };
 
   const handleSelectLocation = (location: string) => {
-    if (province) {
-      const fullLocation = `${province} ${location}`;
-      setSelectedLocation(fullLocation);
+    const fullLocation = `${province} ${location}`;
+    setSelectedLocation(fullLocation);
 
-      const params = new URLSearchParams(searchParams.toString());
+    const params = new URLSearchParams(searchParams.toString());
 
-      params.set('location', fullLocation);
+    params.set('location', fullLocation);
 
-      router.push(`?${params.toString()}`);
-    }
+    router.push(`?${params.toString()}`);
   };
 
   const handleResetLocation = () => {
@@ -124,7 +122,7 @@ export default function LocationSelectDrawerForNav() {
                     </ul>
                   </CommandGroup>
                 )}
-                {province && cities.length > 0 && (
+                {province && (
                   <CommandGroup>
                     <ul className="grid grid-cols-3 gap-3">
                       {cities.map((city) => (

--- a/components/location-select-drawer.tsx
+++ b/components/location-select-drawer.tsx
@@ -30,12 +30,37 @@ interface Props {
 }
 
 export default function LocationSelectDrawer({ defaultLocation, onChange }: Props) {
+  const [isDrawOpen, setIsDrawOpen] = useState(false);
   const [province, setProvince] = useState<string | null>(null);
   const [selectedLocation, setSelectedLocation] = useState<string | null>(null);
 
   const cities = useMemo(() => {
     return province ? LOCATIONS[province] : [];
   }, [province]);
+
+  const handleSelectProvince = (provinceLocation: string) => {
+    if (provinceLocation === '세종특별자치시') {
+      onChange(provinceLocation);
+      setSelectedLocation(provinceLocation);
+      setIsDrawOpen(false);
+    } else {
+      setProvince(provinceLocation);
+    }
+  };
+
+  const handleSelectLocation = (location: string) => {
+    const fullLocation = `${province} ${location}`;
+    onChange(fullLocation);
+    setSelectedLocation(fullLocation);
+    setProvince(null); // 지역선택하면 처음부터 선택하도록 유도하는게 좋을 것 같아서 초기화 시켰습니다.
+    setIsDrawOpen(false);
+  };
+
+  const handleResetLocation = () => {
+    setProvince(null);
+    setSelectedLocation(null);
+    onChange('');
+  };
 
   useEffect(() => {
     if (defaultLocation) {
@@ -44,7 +69,7 @@ export default function LocationSelectDrawer({ defaultLocation, onChange }: Prop
   }, [defaultLocation]);
 
   return (
-    <Drawer>
+    <Drawer open={isDrawOpen} onOpenChange={setIsDrawOpen}>
       <DrawerTrigger className="flex items-center w-full">
         <Input
           type="text"
@@ -69,19 +94,15 @@ export default function LocationSelectDrawer({ defaultLocation, onChange }: Prop
         <div className="px-4">
           <Command>
             <CommandList className="flex p-2 relative justify-center shadow-[inset_0_0_5px_rgb(0,0,0,0.1)]">
-              <CommandEmpty>디폴트 이미지 넣을 예정</CommandEmpty>
-              {province || (
+              <CommandEmpty>지역 초기화를 해주세요!</CommandEmpty>
+              {province === null && (
                 <CommandGroup>
                   <ul className="grid grid-cols-3 gap-3">
                     {Object.keys(LOCATIONS).map((_province) => (
                       <CommandItem
                         key={_province}
                         value={_province}
-                        onSelect={(value) => {
-                          onChange(value);
-                          setSelectedLocation(value);
-                          setProvince(value);
-                        }}
+                        onSelect={handleSelectProvince}
                         className="flex items-center justify-center p-2 font-medium rounded-lg shadow-md hover:bg-gray-100"
                       >
                         {_province}
@@ -97,11 +118,7 @@ export default function LocationSelectDrawer({ defaultLocation, onChange }: Prop
                       <CommandItem
                         key={city}
                         value={city}
-                        onSelect={(value) => {
-                          const fullLocation = `${province} ${value}`;
-                          onChange(fullLocation);
-                          setSelectedLocation(fullLocation);
-                        }}
+                        onSelect={handleSelectLocation}
                         className="flex items-center justify-center p-2 font-medium rounded-lg shadow-md hover:bg-gray-100"
                       >
                         {city}
@@ -116,11 +133,7 @@ export default function LocationSelectDrawer({ defaultLocation, onChange }: Prop
         <DrawerFooter>
           <Button
             type="button"
-            onClick={() => {
-              setProvince(null);
-              setSelectedLocation(null);
-              onChange('');
-            }}
+            onClick={handleResetLocation}
             className="text-base text-white shadow-md bg-slate-800"
           >
             초기화


### PR DESCRIPTION
<img width="421" alt="스크린샷 2024-08-10 오후 4 53 58" src="https://github.com/user-attachments/assets/e034e867-4fef-4bec-8e46-a258cbd2747e">

하단 nav메뉴에 컨텐츠가 가려지는 문제가 있어서 대시보드 페이지 하단에 패딩을 추가해봤고

<img width="421" alt="스크린샷 2024-08-10 오후 4 54 30" src="https://github.com/user-attachments/assets/96502915-8cb0-486a-ac1c-9b4abd6b0956">

상태 표시하는 위치가 고정되어 있지 않아서 애매하다고 생각해

<img width="421" alt="스크린샷 2024-08-10 오후 4 51 58" src="https://github.com/user-attachments/assets/24ec179e-bf28-4bc7-955a-ef34e8bddaf2">

상태 표시는 고정, 버튼만 imageCard의 button contents로 바꿔줬습니다.