### PR TITLE
fix: 위치기반 서비스 로직 수정, 지역 명 수정

### DIFF
--- a/app/(protected)/(main)/activity-list/_components/activity-list.tsx
+++ b/app/(protected)/(main)/activity-list/_components/activity-list.tsx
@@ -22,7 +22,6 @@ export default function ActivityList({ activities, cursorId, sort, location }: P
   const [infinityCursorId, setInfinityCursorId] = useState<string | null>('');
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
-  const [userLocation, setUserLocation] = useState([]);
 
   const loadMoreActivities = useCallback(async () => {
     startTransition(async () => {
@@ -47,11 +46,6 @@ export default function ActivityList({ activities, cursorId, sort, location }: P
   useEffect(() => {
     setInfinityActivities([...activities]);
     setInfinityCursorId(cursorId);
-    const currentLocation = localStorage.getItem('location');
-    if (currentLocation) {
-      const stringifyLocation = JSON.parse(currentLocation);
-      setUserLocation(stringifyLocation);
-    }
   }, [activities, cursorId, location, sort]);
 
   if (activities.length === 0 && searchParams.get('sort') === 'tag') {
@@ -80,7 +74,7 @@ export default function ActivityList({ activities, cursorId, sort, location }: P
         {infinityActivities.map((activity, index) => (
           <li key={activity.id}>
             <ActivityListCard activity={activity} />
-            {index === 4 && <ActivityCarousel userLocation={userLocation} />}
+            {index === 4 && <ActivityCarousel />}
           </li>
         ))}
         <div ref={observer} />

--- a/app/(protected)/(user)/profile/edit/page.tsx
+++ b/app/(protected)/(user)/profile/edit/page.tsx
@@ -13,7 +13,7 @@ export default async function Page() {
   const userData = await getUserProfileWithIntroducedInfos(userId);
 
   return (
-    <main className="p-5 tall:h-[calc(100vh-64px-71px)] pb-20">
+    <main className="p-5 tall:min-h-screen tall:pb-5 pb-20">
       <Card className="shadow-md">
         <CardHeader className="flex flex-col gap-5">
           <CardTitle className="font-bold text-center">

--- a/app/(protected)/(user)/profile/page.tsx
+++ b/app/(protected)/(user)/profile/page.tsx
@@ -8,7 +8,7 @@ export default async function Page() {
   const userData = await getUserProfileWithIntroducedInfos(userId);
 
   return (
-    <main className="p-5 tall:h-[calc(100vh-64px-71px)] pb-20">
+    <main className="p-5 tall:min-h-screen tall:pb-5 pb-20">
       <Card className="shadow-md">
         <CardHeader className="flex flex-col gap-5">
           <CardTitle className="font-bold">

--- a/constants/locations.ts
+++ b/constants/locations.ts
@@ -158,7 +158,7 @@ const LOCATIONS: Locations = {
       { state: '연천군', location: { latitude: 38.084, longitude: 127.177 } }, // 연천군청
     ],
   },
-  강원도: {
+  강원특별자치도: {
     id: 12,
     list: [
       { state: '춘천시', location: { latitude: 37.8804, longitude: 127.7263 } }, // 춘천시청
@@ -267,7 +267,7 @@ const LOCATIONS: Locations = {
       { state: '합천군', location: { latitude: 35.5686, longitude: 128.1595 } }, // 합천군청
     ],
   },
-  전라북도: {
+  전북특별자치도: {
     id: 17,
     list: [
       { state: '전주시', location: { latitude: 35.8244, longitude: 127.148 } }, // 전주시청


### PR DESCRIPTION
위치기반 기능에 문제점들이 있어서 localstorage에 저장하는 로직을 삭제했습니다.
여기서 설정한 로케이션값을 다른 곳에서 사용하지도 않고 새로고침되거나 값이 설정되었을때 useEffect로만 컨트롤하기에 힘들어서 변경했습니다.
추가적으로 지역명중에 전북,강원은 특별자치도라서 변경하고
주소를 받아오면 광역시 이상 도시에선 문제없는데 이하 도시에서는 두번째 주소에 시와 구까지 확인되어서 띄어쓰기 감지해서 첫부분만 사용하도록 설정했습니다.