### PR TITLE
fix: 날짜 지난활동 스타일 및 기능 구현 및 근처 추천 리스트 위치 수정

### DIFF
--- a/app/(protected)/(detail)/activity/[activityId]/_components/promise-request-form.tsx
+++ b/app/(protected)/(detail)/activity/[activityId]/_components/promise-request-form.tsx
@@ -16,6 +16,8 @@ interface Props {
 export default function PromiseRequestForm({ startDate, endDate, maxCount, activityId }: Props) {
   const [isPending, startTransition] = useTransition();
   const formatDate = formatDateRange({ startDateString: startDate, endDateString: endDate });
+  const nowDate = new Date();
+  const activityStatus = endDate < nowDate;
 
   const applyActivity = () => {
     startTransition(async () => {
@@ -34,7 +36,7 @@ export default function PromiseRequestForm({ startDate, endDate, maxCount, activ
         type="button"
         className="px-4 py-2 text-sm font-semibold text-white border border-none rounded-md bg-primary hover:bg-primary_dark"
         onClick={applyActivity}
-        disabled={isPending}
+        disabled={isPending || activityStatus}
       >
         약속잡기
       </Button>

--- a/app/(protected)/(main)/activity-list/_components/activity-carousel.tsx
+++ b/app/(protected)/(main)/activity-list/_components/activity-carousel.tsx
@@ -96,16 +96,15 @@ export default function ActivityCarousel() {
   }, [userLocation]);
 
   return (
-    <div className="bg-gray_200 py-5 flex flex-col gap-5 mt-6 rounded-lg">
+    <div className="border py-5 flex flex-col gap-5 mb-6 rounded-lg">
       {userLocation[0] ? (
         <>
           <p className="text-xl font-semibold px-5">
             나랑 가까운
             <span className="text-xl text-primary"> 길라</span>를 추천해드릴께요!
-            {}
           </p>
           {recommendList[0] ? (
-            <div className="overflow-x-scroll [&::-webkit-scrollbar]:hidden">
+            <div className="overflow-x-scroll [&::-webkit-scrollbar]:hidden h-full">
               <ul className="flex gap-4  w-fit">
                 {recommendList.map((item, index) => (
                   <li

--- a/app/(protected)/(main)/activity-list/_components/activity-carousel.tsx
+++ b/app/(protected)/(main)/activity-list/_components/activity-carousel.tsx
@@ -96,7 +96,7 @@ export default function ActivityCarousel() {
   }, [userLocation]);
 
   return (
-    <div className="border py-5 flex flex-col gap-5 mb-6 rounded-lg">
+    <div className="border py-5 flex flex-col gap-5 rounded-lg">
       {userLocation[0] ? (
         <>
           <p className="text-xl font-semibold px-5">

--- a/app/(protected)/(main)/activity-list/_components/activity-list-card.tsx
+++ b/app/(protected)/(main)/activity-list/_components/activity-list-card.tsx
@@ -13,12 +13,16 @@ interface Props {
 export default function ActivityListCard({ activity }: Props) {
   const { title, startDate, endDate, location, views, _count, user, thumbnails } = activity;
   const formatDate = formatDateRange({ startDateString: startDate, endDateString: endDate });
+  const nowDate = new Date();
 
   return (
     <Link href={`/activity/${activity.id}`}>
-      <Card className="h-[400px] flex flex-col items-start border-none shadow-md hover:shadow-xl bg-white">
+      <Card className="h-[400px] flex flex-col items-start border-none shadow-md hover:shadow-xl bg-white relative">
+        {endDate < nowDate && (
+          <div className="absolute inset-0 opacity-50 bg-gray_300 rounded-lg z-10 flex flex-col justify-center items-center" />
+        )}
         <div className="flex justify-center w-full h-full row-span-2 px-2 pt-2 rounded-md">
-          <div className="relative w-full h-full rounded-md">
+          <div className="relative w-full h-full rounded-md flex justify-center items-center">
             <Image
               src={thumbnails[0] || '/default-carousel-image.png'}
               alt="thumbnail"
@@ -26,6 +30,9 @@ export default function ActivityListCard({ activity }: Props) {
               sizes="(max-width: 768px) 100vw"
               style={{ objectFit: 'cover', borderRadius: '8px' }}
             />
+            {endDate < nowDate && (
+              <p className="absolute font-bold text-xl z-30">지난 활동입니다!</p>
+            )}
           </div>
         </div>
         <div className="flex flex-col w-full row-span-1 gap-1 p-2">

--- a/app/(protected)/(main)/activity-list/_components/activity-list.tsx
+++ b/app/(protected)/(main)/activity-list/_components/activity-list.tsx
@@ -71,10 +71,10 @@ export default function ActivityList({ activities, cursorId, sort, location }: P
   return (
     <>
       <ul className="flex flex-col w-full gap-6">
-        {infinityActivities.map((activity, index) => (
+        <ActivityCarousel />
+        {infinityActivities.map((activity) => (
           <li key={activity.id}>
             <ActivityListCard activity={activity} />
-            {index === 4 && <ActivityCarousel />}
           </li>
         ))}
         <div ref={observer} />

--- a/app/(protected)/(main)/activity-list/_components/activity-list.tsx
+++ b/app/(protected)/(main)/activity-list/_components/activity-list.tsx
@@ -8,7 +8,7 @@ import { getActivities } from '@/app/data/activity';
 import useInfiniteScroll from '@/hooks/useInfiniteScroll';
 import { ActivityWithUserAndFavoCount, Sort } from '@/type';
 import ActivityCardSkeleton from '@/components/skeletons/activity-card-skeleton';
-import ActivityCarousel from './activity-carousel';
+import ActivitySlideContainer from './activity-slide-container';
 
 interface Props {
   activities: ActivityWithUserAndFavoCount[];
@@ -71,7 +71,7 @@ export default function ActivityList({ activities, cursorId, sort, location }: P
   return (
     <>
       <ul className="flex flex-col w-full gap-6">
-        <ActivityCarousel />
+        <ActivitySlideContainer />
         {infinityActivities.map((activity) => (
           <li key={activity.id}>
             <ActivityListCard activity={activity} />

--- a/app/(protected)/(main)/activity-list/_components/activity-slide-container.tsx
+++ b/app/(protected)/(main)/activity-list/_components/activity-slide-container.tsx
@@ -3,17 +3,18 @@
 
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useTransition } from 'react';
 import { getActivitiesByLocation } from '@/app/data/activity';
 import { ActivityWithUserAndFavoCount } from '@/type';
 import ActivityCardSkeleton from '@/components/skeletons/activity-card-skeleton';
 import LOCATIONS from '@/constants/locations';
 import calculateDistanceInMeters from '@/utils/calculateDistance';
-import ActivityListCard from './activity-list-card';
+import ActivitySlide from './activity-slide';
 
-export default function ActivityCarousel() {
+export default function ActivitySlideContainer() {
   const [recommendList, setRecommentList] = useState<ActivityWithUserAndFavoCount[]>([]);
   const [userLocation, setUserLocation] = useState<string[]>([]);
+  const [isPending, startTransition] = useTransition();
 
   const getAddress = (mapResult: any, mapStatus: any) => {
     if (mapStatus === window.kakao.maps.services.Status.OK) {
@@ -80,13 +81,15 @@ export default function ActivityCarousel() {
     }
   }, [onLoadKakaoMap]);
 
-  const activityByLocation = async (location: string[]) => {
-    const result = await getActivitiesByLocation({
-      location: location[0],
-      secondeLocation: location[1],
-      size: 5,
+  const activityByLocation = (location: string[]) => {
+    startTransition(async () => {
+      const result = await getActivitiesByLocation({
+        location: location[0],
+        secondeLocation: location[1],
+        size: 5,
+      });
+      setRecommentList([...result.activities]);
     });
-    setRecommentList([...result.activities]);
   };
 
   useEffect(() => {
@@ -97,45 +100,20 @@ export default function ActivityCarousel() {
 
   return (
     <div className="border py-5 flex flex-col gap-5 rounded-lg">
-      {userLocation[0] ? (
-        <>
-          <p className="text-xl font-semibold px-5">
-            나랑 가까운
-            <span className="text-xl text-primary"> 길라</span>를 추천해드릴께요!
-          </p>
-          {recommendList[0] ? (
-            <div className="overflow-x-scroll [&::-webkit-scrollbar]:hidden h-full">
-              <ul className="flex gap-4  w-fit">
-                {recommendList.map((item, index) => (
-                  <li
-                    key={item.id}
-                    className={`w-[280px] ${index === 0 && 'ml-5'} ${recommendList.length - 1 === index && 'mr-5'}`}
-                  >
-                    <ActivityListCard activity={item} />
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ) : (
-            <div className="px-5">
-              <div>
-                <p className="text-xl font-semibold">근처에서 길라를 찾을 수 없어요!</p>
-              </div>
-              <div>
-                <ActivityCardSkeleton />
-              </div>
-            </div>
-          )}
-        </>
+      <div className="flex flex-col gap-1 px-5">
+        <p className="text-xl font-semibold">
+          나랑 가까운
+          <span className="text-xl text-primary"> 길라</span>를 추천해드릴께요!
+        </p>
+        {!userLocation[0] && (
+          <p className="text-xs">※ 위치 권한 설정을 하지 않으면 이용할 수 없는 기능입니다.</p>
+        )}
+      </div>
+      {userLocation[0] && !isPending ? (
+        <ActivitySlide recommendList={recommendList} />
       ) : (
         <div className="px-5">
-          <div>
-            <p className="text-xl font-semibold">위치 권한을 허용해주세요!</p>
-            <p className="text-sm">접속하신 지역을 기준으로 길라를 추천해드릴께요!</p>
-          </div>
-          <div>
-            <ActivityCardSkeleton />
-          </div>
+          <ActivityCardSkeleton />
         </div>
       )}
     </div>

--- a/app/(protected)/(main)/activity-list/_components/activity-slide.tsx
+++ b/app/(protected)/(main)/activity-list/_components/activity-slide.tsx
@@ -1,0 +1,37 @@
+import ActivityCardSkeleton from '@/components/skeletons/activity-card-skeleton';
+import { ActivityWithUserAndFavoCount } from '@/type';
+import ActivityListCard from './activity-list-card';
+
+export default function ActivitySlide({
+  recommendList,
+}: {
+  recommendList: ActivityWithUserAndFavoCount[];
+}) {
+  return (
+    <div>
+      {recommendList[0] ? (
+        <div className="overflow-x-scroll [&::-webkit-scrollbar]:hidden h-full">
+          <ul className="flex gap-4  w-fit">
+            {recommendList.map((item, index) => (
+              <li
+                key={item.id}
+                className={`w-[280px] ${index === 0 && 'ml-5'} ${recommendList.length - 1 === index && 'mr-5'}`}
+              >
+                <ActivityListCard activity={item} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <div className="px-5">
+          <div>
+            <p className="text-xl font-semibold">근처에서 길라를 찾을 수 없어요!</p>
+          </div>
+          <div>
+            <ActivityCardSkeleton />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
![스크린샷 2024-08-19 오후 11 05 30](https://github.com/user-attachments/assets/217f1109-2c24-4ec3-9c67-5f36a682a320)
지난 활동을 들어갈수 있다는 가정으로 코드 작성했습니다. bg색상 변경하고 텍스트 추가했고
![스크린샷 2024-08-19 오후 11 07 16](https://github.com/user-attachments/assets/01e44f8a-7ee8-4083-afc8-5820dee3bd08)
지난 활동은 버튼도 비활성화 시켜놨습니다. 아직 즐겨찾기는 어떻게 할지 애매해서 아직은 활성화 상태입니다.
그리고 주현님 말씀하신대로 슬라이드 상단으로 이동시켜놨습니다. 이게 더 나은것 같네요.