### PR TITLE
닉네임 중복 방지 기능 구현

### DIFF
--- a/app/action/user.ts
+++ b/app/action/user.ts
@@ -23,9 +23,8 @@ export const findUserByNickname = async (nickname: string): Promise<ActionType<U
         success: false,
         message: '동일한 닉네임이 존재합니다.',
       };
-    } else {
-      return null;
     }
+    return null;
   } catch (error) {
     return {
       success: false,

--- a/app/data/user.ts
+++ b/app/data/user.ts
@@ -145,3 +145,15 @@ export const getIsFirstLogin = async (): Promise<boolean> => {
     throw new Error('첫 로그인 여부를 가져오는 중에 에러가 발생하였습니다.');
   }
 };
+
+export const getUserNameById = async (userId: string): Promise<string> => {
+  try {
+    const user = await db.user.findUnique({
+      where: { id: userId },
+    });
+    if (!user) throw new Error('해당 유저 정보가 존재하지 않습니다.');
+    return user.nickname;
+  } catch (error) {
+    throw new Error('유저닉네임을 가져오는 중에 에러가 발생하였습니다.');
+  }
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,7 +48,7 @@ model VerificationToken {
 
 model User {
   id               String            @id @default(cuid())
-  nickname         String
+  nickname         String            @unique
   email            String            @unique
   password         String
   emailVerified    DateTime?         @map("email_verified")


### PR DESCRIPTION
채팅 기능 구현 중 닉네임이 중복되면 구현되기 어려운 부분이 있어서 닉네임 중복되지 않도록 구현했습니다.
기존과 동일하게 동일한 닉네임이 있는 경우 에러 토스트로 확인 가능합니다.