### PR TITLE
채팅관련 대시보드 카드 기능 추가 및 스타일 수정

### DIFF
--- a/app/(protected)/(user)/dashboard/my-chat/_components/channel.tsx
+++ b/app/(protected)/(user)/dashboard/my-chat/_components/channel.tsx
@@ -1,4 +1,7 @@
 import { ActivityWithFavoriteAndCount } from '@/type';
+import formatDateRange from '@/utils/formatDateRange';
+import { User } from 'lucide-react';
+import Image from 'next/image';
 import Link from 'next/link';
 
 interface Props {
@@ -6,9 +9,34 @@ interface Props {
 }
 
 export default function Channel({ activity }: Props) {
+  const dateRange = formatDateRange({
+    startDateString: activity.startDate,
+    endDateString: activity.endDate,
+  });
+
   return (
     <Link href={`/chat/${activity.id}`}>
-      <div className="border rounded-lg h-20">{activity.title}</div>
+      <div className="relative flex items-center w-full p-3 overflow-hidden text-xs border rounded-md gap-4">
+        <div className="relative w-24 h-24">
+          <Image
+            src={activity.thumbnails[0] || '/default-carousel-image.png'}
+            alt="썸네일"
+            fill
+            objectFit="cover"
+            className="rounded-3xl"
+          />
+        </div>
+        <div className="flex flex-col justify-center gap-3">
+          <div className="flex items-center gap-2">
+            <h1 className="text-lg font-semibold truncate max-w-48">{activity.title}</h1>
+            <div className="flex justify-center items-center gap-1">
+              <User width={14} height={14} />
+              <p className="text-lg text-gray_500">{activity.maximumCount}</p>
+            </div>
+          </div>
+          <p className="text-sm text-nowrap">{dateRange}</p>
+        </div>
+      </div>
     </Link>
   );
 }

--- a/app/(protected)/(user)/dashboard/promise-list/_components/promise-list-card.tsx
+++ b/app/(protected)/(user)/dashboard/promise-list/_components/promise-list-card.tsx
@@ -8,6 +8,7 @@ import { toast } from 'sonner';
 import { useRouter } from 'next/navigation';
 import formatDateRange from '@/utils/formatDateRange';
 import DeleteAlertModal from '@/components/delete-alert-modal';
+import SmallButton from '@/components/small-button';
 
 export default function PromiseListCard({ promise }: { promise: RequestWithActivity }) {
   const router = useRouter();
@@ -24,6 +25,60 @@ export default function PromiseListCard({ promise }: { promise: RequestWithActiv
     router.refresh();
   };
 
+  const enterChat = () => {
+    router.push(`/chat/${promise.activityId}`);
+  };
+
+  if (promise.status === 'PENDING')
+    return (
+      <ImageCard
+        activityId={id}
+        title={title}
+        imageSrc={thumbnails[0]}
+        middleContent={
+          <>
+            <p className="text-sm font-semibold text-gray-900">{formatDate}</p>
+            <div className="text-sm font-semibold text-gray-900">
+              <p>최대 인원: {maximumCount} 명</p>
+            </div>
+            <PromiseStatus status={promise.status} />
+          </>
+        }
+        bottomContent={
+          <div className="absolute bottom-2 right-2 flex gap-32">
+            <div className="w-[70px]" onClick={(e) => e.preventDefault()}>
+              <DeleteAlertModal deleteAction={cancelPromise} isButton content="취소" />
+            </div>
+          </div>
+        }
+      />
+    );
+
+  if (promise.status === 'APPROVE')
+    return (
+      <ImageCard
+        activityId={id}
+        title={title}
+        imageSrc={thumbnails[0]}
+        middleContent={
+          <>
+            <p className="text-sm font-semibold text-gray-900">{formatDate}</p>
+            <div className="text-sm font-semibold text-gray-900">
+              <p>최대 인원: {maximumCount} 명</p>
+            </div>
+            <PromiseStatus status={promise.status} />
+          </>
+        }
+        bottomContent={
+          <div className="absolute bottom-2 right-2 flex gap-32">
+            <div className="w-[70px]" onClick={(e) => e.preventDefault()}>
+              <SmallButton onClick={enterChat} color="bg-green" name="입장" />
+            </div>
+          </div>
+        }
+      />
+    );
+
   return (
     <ImageCard
       activityId={id}
@@ -37,15 +92,6 @@ export default function PromiseListCard({ promise }: { promise: RequestWithActiv
           </div>
           <PromiseStatus status={promise.status} />
         </>
-      }
-      bottomContent={
-        promise.status === 'PENDING' && (
-          <div className="absolute bottom-2 right-2 flex gap-32">
-            <div className="w-[70px]" onClick={(e) => e.preventDefault()}>
-              <DeleteAlertModal deleteAction={cancelPromise} isButton content="취소" />
-            </div>
-          </div>
-        )
       }
     />
   );


### PR DESCRIPTION
![스크린샷 2024-08-24 오후 6 59 29](https://github.com/user-attachments/assets/28bb295c-0657-4f1c-a83d-24bf6297176f)
대시보드에 채팅 추가해서 리스트 카드 추가해놨습니다. 지금 인원수는 maximumcount로 되어있는데 액티비티에 참가자 모델 집어 넣어주면 해당 데이터로 교체해주면 좋을 것 같네요

![스크린샷 2024-08-24 오후 7 35 10](https://github.com/user-attachments/assets/f6c3a528-d63d-448b-adb8-cbe44e630367)
추가적으로 내가 신청한 활동에서 수락되었을때 채팅방으로 이동가능한 링크 버튼 추가해줬습니다. 버튼 누르면 `/chat/activityId`로 이동합니다.