### PR TITLE
endDate 지난 활동 처리

### DIFF
--- a/app/(protected)/(main)/activity-list/_components/activity-slide.tsx
+++ b/app/(protected)/(main)/activity-list/_components/activity-slide.tsx
@@ -45,7 +45,7 @@ export default function ActivitySlide({
     if (slideRef.current) {
       if (slideRef.current.firstElementChild) {
         setSlideScrollDistance(
-          slideRef.current.firstElementChild.clientWidth / recommendList.length,
+          slideRef.current.firstElementChild.scrollWidth / recommendList.length,
         );
       }
     }

--- a/app/(protected)/(user)/dashboard/my-activity/_components/my-activity-card.tsx
+++ b/app/(protected)/(user)/dashboard/my-activity/_components/my-activity-card.tsx
@@ -19,6 +19,7 @@ export default function MyActivityCard({ activity }: Props) {
   const dateRange = formatDateRange({ startDateString: startDate, endDateString: endDate });
   const [isPending, startTransition] = useTransition();
   const [isEditModalOpen, setEditModalOpen] = useState<boolean>(false);
+  const nowDate = new Date();
 
   const handleClickEditFormOpen: MouseEventHandler = (e) => {
     e.preventDefault();
@@ -63,14 +64,16 @@ export default function MyActivityCard({ activity }: Props) {
                 <p>조회수 {views}</p>
               </div>
               <div className="flex w-full gap-2">
-                <Button
-                  disabled={isPending}
-                  type="button"
-                  className="w-full text-base font-medium text-white shadow"
-                  onClick={handleClickEditFormOpen}
-                >
-                  수정
-                </Button>
+                {endDate > nowDate && (
+                  <Button
+                    disabled={isPending}
+                    type="button"
+                    className="w-full text-base font-medium text-white shadow"
+                    onClick={handleClickEditFormOpen}
+                  >
+                    수정
+                  </Button>
+                )}
                 <div className="w-full" onClick={(e) => e.preventDefault()}>
                   <DeleteAlertModal deleteAction={handleDelete} isButton content="삭제" />
                 </div>

--- a/app/(protected)/(user)/dashboard/my-activity/page.tsx
+++ b/app/(protected)/(user)/dashboard/my-activity/page.tsx
@@ -11,7 +11,7 @@ export default async function Page() {
   const user = await getCurrentUser();
 
   return (
-    <main className="p-5 min-h-[calc(100vh-64px-86px)]">
+    <main className="p-5 min-h-[calc(100vh-64px-71px)]">
       <div className="flex items-center justify-between w-full pb-5">
         <div>
           <h1 className="text-2xl font-bold">

--- a/app/(protected)/(user)/dashboard/my-chat/page.tsx
+++ b/app/(protected)/(user)/dashboard/my-chat/page.tsx
@@ -9,7 +9,7 @@ export default async function Page() {
   const user = await getCurrentUser();
 
   return (
-    <main className="p-5 min-h-[calc(100vh-64px-86px)]">
+    <main className="p-5 min-h-[calc(100vh-64px-71px)]">
       <div className="flex items-center justify-between w-full pb-5">
         <div>
           <h1 className="text-2xl font-bold">

--- a/app/(protected)/(user)/dashboard/my-chat/page.tsx
+++ b/app/(protected)/(user)/dashboard/my-chat/page.tsx
@@ -1,11 +1,11 @@
-import { getMyActivities } from '@/app/data/activity';
 import { getCurrentUser } from '@/app/data/user';
 import { Suspense } from 'react';
+import getMyChat from '@/app/data/chat';
 import Loading from '../loading';
 import ChatChannelList from './_components/chat-channel-list';
 
 export default async function Page() {
-  const { activities, cursorId } = await getMyActivities({ take: 7 });
+  const { activities, cursorId } = await getMyChat({ take: 7 });
   const user = await getCurrentUser();
 
   return (

--- a/app/(protected)/(user)/dashboard/my-question/page.tsx
+++ b/app/(protected)/(user)/dashboard/my-question/page.tsx
@@ -5,7 +5,7 @@ import MyQuestionCreateModal from '@/app/(protected)/(user)/dashboard/my-questio
 export default async function Page() {
   const myQuestions = await getMyQuestions({ take: 10, answerTake: 5 });
   return (
-    <div className="p-5 min-h-[calc(100vh-64px-86px)]">
+    <div className="p-5 min-h-[calc(100vh-64px-71px)]">
       <div className="flex justify-between w-full mb-5">
         <h1 className="text-2xl font-bold">내 질문</h1>
         <MyQuestionCreateModal />

--- a/app/(protected)/(user)/dashboard/promise-list/_components/promise-list.tsx
+++ b/app/(protected)/(user)/dashboard/promise-list/_components/promise-list.tsx
@@ -27,7 +27,7 @@ export default function PromiseList({ promiseList, cursorId }: Props) {
         cursor: infinityCursorId,
       });
       setInfinityCursorId(result.cursorId);
-      setInfinityPromise((prev) => [...prev, ...result.requests]);
+      setInfinityPromise((prev) => [...prev, ...result.validRequests]);
     });
   }, [infinityCursorId]);
 

--- a/app/(protected)/(user)/dashboard/promise-list/page.tsx
+++ b/app/(protected)/(user)/dashboard/promise-list/page.tsx
@@ -15,7 +15,7 @@ export default async function Page() {
         <p className="text-base font-medium">신청이 수락되면 참가자들과 소통할 수 있어요!</p>
       </h1>
       <Suspense fallback={<Loading />}>
-        <PromiseList promiseList={myPromise.requests} cursorId={myPromise.cursorId} />
+        <PromiseList promiseList={myPromise.validRequests} cursorId={myPromise.cursorId} />
       </Suspense>
     </main>
   );

--- a/app/(protected)/(user)/dashboard/promise-list/page.tsx
+++ b/app/(protected)/(user)/dashboard/promise-list/page.tsx
@@ -9,7 +9,7 @@ export default async function Page() {
   const user = await getCurrentUser();
 
   return (
-    <main className="p-5 min-h-[calc(100vh-64px-86px)] flex flex-col gap-4">
+    <main className="p-5 min-h-[calc(100vh-64px-71px)] flex flex-col gap-4">
       <h1 className="w-full text-2xl font-bold">
         <span className="text-3xl text-primary">{user.nickname}</span>님이 신청한 활동
         <p className="text-base font-medium">신청이 수락되면 참가자들과 소통할 수 있어요!</p>

--- a/app/(protected)/(user)/dashboard/promised-list/page.tsx
+++ b/app/(protected)/(user)/dashboard/promised-list/page.tsx
@@ -9,7 +9,7 @@ export default async function Page() {
   const user = await getCurrentUser();
 
   return (
-    <main className="p-5 min-h-[calc(100vh-64px-86px)] flex flex-col gap-4">
+    <main className="p-5 min-h-[calc(100vh-64px-71px)] flex flex-col gap-4">
       <h1 className="w-full text-2xl font-bold">
         <span className="text-3xl text-primary">{user.nickname}</span>님과 함께하고 싶대요!
       </h1>

--- a/app/(protected)/(user)/dashboard/reviews/page.tsx
+++ b/app/(protected)/(user)/dashboard/reviews/page.tsx
@@ -6,7 +6,7 @@ export default async function Page() {
   const { activities, cursorId } = activitiesRes;
 
   return (
-    <main className="flex flex-col gap-4 p-5 min-h-[calc(100vh-64px-86px)] tall:pb-0 pb-20">
+    <main className="flex flex-col gap-4 p-5 min-h-[calc(100vh-64px-71px)] tall:pb-0 pb-20">
       <h1 className="text-2xl font-bold">이전 활동은 어땠나요?</h1>
       <ReviewList activities={activities} cursorId={cursorId} />
     </main>

--- a/app/(protected)/(user)/dashboard/wishlist/page.tsx
+++ b/app/(protected)/(user)/dashboard/wishlist/page.tsx
@@ -7,7 +7,7 @@ export default async function Page() {
   const { favorites, cursorId } = await getMyFavorites({ take: 10 });
 
   return (
-    <main className="p-5 min-h-[calc(100vh-64px-86px)] flex flex-col gap-4">
+    <main className="p-5 min-h-[calc(100vh-64px-71px)] flex flex-col gap-4">
       <h1 className="text-2xl font-bold">저장한 활동</h1>
       <Suspense fallback={<Loading />}>
         <WishListContainer initialFavorites={favorites} initialCursorId={cursorId} />

--- a/app/data/activity-request.ts
+++ b/app/data/activity-request.ts
@@ -57,9 +57,10 @@ export const getMyReceivedRequests = async ({
 }): Promise<{ requests: RequestWithReqUserAndActivity[]; cursorId: string | null }> => {
   try {
     const currentUserId = await getCurrentUserId();
+    const nowDate = new Date();
 
     const userActivities = await db.activity.findMany({
-      where: { userId: currentUserId },
+      where: { userId: currentUserId, endDate: { gte: nowDate } },
       select: {
         activityRequests: {
           where: {

--- a/app/data/activity.ts
+++ b/app/data/activity.ts
@@ -18,11 +18,10 @@ export const getMyActivities = async ({
   take?: number;
 }): Promise<{ activities: ActivityWithFavoriteAndCount[]; cursorId: string | null }> => {
   const userId = await getCurrentUserId();
-  const nowDate = new Date();
 
   try {
     const myActivities = await db.activity.findMany({
-      where: { userId, endDate: { gte: nowDate } },
+      where: { userId },
       include: {
         _count: {
           select: { favorites: true },

--- a/app/data/activity.ts
+++ b/app/data/activity.ts
@@ -18,9 +18,11 @@ export const getMyActivities = async ({
   take?: number;
 }): Promise<{ activities: ActivityWithFavoriteAndCount[]; cursorId: string | null }> => {
   const userId = await getCurrentUserId();
+  const nowDate = new Date();
+
   try {
     const myActivities = await db.activity.findMany({
-      where: { userId },
+      where: { userId, endDate: { gte: nowDate } },
       include: {
         _count: {
           select: { favorites: true },

--- a/app/data/chat.ts
+++ b/app/data/chat.ts
@@ -1,0 +1,54 @@
+import { getCurrentUserId } from '@/app/data/user';
+import db from '@/lib/db';
+import { ActivityWithFavoriteAndCount } from '@/type';
+
+const getMyChat = async ({
+  cursor,
+  take = 10,
+}: {
+  cursor?: string;
+  take?: number;
+}): Promise<{ activities: ActivityWithFavoriteAndCount[]; cursorId: string | null }> => {
+  const userId = await getCurrentUserId();
+  const nowDate = new Date();
+
+  try {
+    const myActivities = await db.activity.findMany({
+      where: { userId, endDate: { gte: nowDate } },
+      include: {
+        _count: {
+          select: { favorites: true },
+        },
+        favorites: {
+          where: {
+            userId,
+          },
+          select: {
+            id: true,
+          },
+        },
+      },
+      take,
+      cursor: cursor ? { id: cursor } : undefined,
+      skip: cursor ? 1 : 0,
+      orderBy: {
+        createdAt: 'asc',
+      },
+    });
+
+    const lastActivity = myActivities[myActivities.length - 1];
+    const cursorId = lastActivity ? lastActivity.id : null;
+
+    // Map over activities and add `isFavo` property
+    const activitiesWithFavo = myActivities.map((activity) => {
+      const isFavorite = activity.favorites.length > 0;
+      return { ...activity, isFavorite };
+    });
+
+    return { activities: activitiesWithFavo, cursorId };
+  } catch (error) {
+    throw new Error('활동을 가져오는 중에 에러가 발생하였습니다.');
+  }
+};
+
+export default getMyChat;


### PR DESCRIPTION
메인 리스트에서는 지난 활동까지 전부 보이도록 되어있어서 대시보드에서도 통일성있게 endDate가 지난 활동 처리를 해봤습니다.

<img width="1552" alt="스크린샷 2024-08-26 오후 1 44 06" src="https://github.com/user-attachments/assets/35c30980-be82-400f-b71b-4945b665e291">
내가 등록한 활동은 날짜가 지나면 수정 버튼이 없어지도록 만들어줬습니다.
<img width="1552" alt="스크린샷 2024-08-26 오후 1 44 37" src="https://github.com/user-attachments/assets/d8943ba9-a77b-4ddb-89c4-3bea057d5b12">
내가 신청한 활동은 날짜가 지난 활동은 제외했습니다.
<img width="1552" alt="스크린샷 2024-08-26 오후 1 45 12" src="https://github.com/user-attachments/assets/261b975f-d3b7-4da3-afb9-f68a896173f3">
신청 받은 활동도 날짜가 지나면 제외했습니다.
<img width="1552" alt="스크린샷 2024-08-26 오후 1 45 37" src="https://github.com/user-attachments/assets/d0c1c480-3b64-4d2b-93b2-17b48c01b602">
채팅 채널은 기존의 activity받아오는 로직사용하다가 이번에 분리시켜서 날짜 지난 활동은 제외시켰습니다.
