### PR TITLE
사이드 메뉴 구현

### DIFF
--- a/app/(protected)/(detail)/activity/[activityId]/_components/detail-carousel.tsx
+++ b/app/(protected)/(detail)/activity/[activityId]/_components/detail-carousel.tsx
@@ -81,7 +81,7 @@ export default function DetailCarousel({ thumbnails }: { thumbnails: string[] })
 
       {selectedImage && (
         <Dialog open={!!selectedImage} onOpenChange={handleClose}>
-          <DialogContent className="z-50 w-full h-auto max-w-md p-4 mx-auto my-8 border-none">
+          <DialogContent className="z-50 w-full h-auto max-w-md p-4 mx-auto my-8 border-none tall:left-[calc(50vw-10px)] tall:translate-x-0 tall:max-w-[420px]">
             <DialogTitle aria-describedby={undefined} />
             <DialogDescription aria-describedby={undefined} />
             <div className="relative w-full h-full max-w-full max-h-full">

--- a/app/(protected)/chat/[[...channel]]/_components/message-input.tsx
+++ b/app/(protected)/chat/[[...channel]]/_components/message-input.tsx
@@ -27,7 +27,9 @@ export default function MessageInput({ onSubmit }: Props) {
         onChange={handleChange}
         placeholder="메세지를 입력하세요"
       />
-      <Button className="text-white font-semibold">전송</Button>
+      <Button className="text-white font-semibold" disabled={inputValue.length === 0}>
+        전송
+      </Button>
     </form>
   );
 }

--- a/components/common/nav-base.tsx
+++ b/components/common/nav-base.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { getCurrentUser } from '@/app/data/user';
-import NavDropdown from '@/components/common/nav-dropdown';
+import NavSideMenu from './nav-sidemenu';
 
 export default async function NavigationBase({ children }: { children?: ReactNode }) {
   const { image } = await getCurrentUser();
@@ -25,7 +25,7 @@ export default async function NavigationBase({ children }: { children?: ReactNod
       </div>
       {children && <div className="col-span-2">{children}</div>}
       <div className="flex items-center justify-end w-[70px]">
-        <NavDropdown userAvatar={image} />
+        <NavSideMenu userAvatar={image} />
       </div>
     </nav>
   );

--- a/components/common/nav-sidemenu.tsx
+++ b/components/common/nav-sidemenu.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { Sheet, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet';
 import Image from 'next/image';
 import { CircleUserRound } from 'lucide-react';
 import Link from 'next/link';
@@ -10,6 +16,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import { logout } from '@/app/action/user';
 import { toast } from 'sonner';
 import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
+import { Separator } from '../ui/separator';
 
 interface Props {
   userAvatar: string | null;
@@ -65,23 +72,27 @@ export default function NavSideMenu({ userAvatar }: Props) {
       </SheetTrigger>
       <SheetContent className="border-none bg-opacity-90 bg-white_light" side="left">
         <SheetTitle>메뉴</SheetTitle>
-        <Link
-          href="/profile"
-          className={cn(
-            pathname === '/profile' && 'bg-gray-200',
-            'flex items-center justify-center w-full text-black hover:bg-gray-200',
-          )}
-        >
-          프로필
-        </Link>
-        <button
-          disabled={isPending}
-          onClick={Logout}
-          type="button"
-          className="flex items-center justify-center w-full text-black hover:bg-gray-200"
-        >
-          로그아웃
-        </button>
+        <SheetDescription aria-describedby={undefined} />
+        <div className="flex flex-col p-2 gap-2">
+          <Link
+            href="/profile"
+            className={cn(
+              pathname === '/profile' && 'bg-gray-200',
+              'flex items-center justify-center w-full  hover:bg-gray-300 h-14 rounded-lg',
+            )}
+          >
+            <p className="text-black font-semibold">프로필</p>
+          </Link>
+          <Separator className="bg-gray_300" />
+          <button
+            disabled={isPending}
+            onClick={Logout}
+            type="button"
+            className="flex items-center justify-center w-full text-black hover:bg-gray-300 h-14 rounded-lg"
+          >
+            <p className="text-black font-semibold">로그아웃</p>
+          </button>
+        </div>
       </SheetContent>
     </Sheet>
   );

--- a/components/common/nav-sidemenu.tsx
+++ b/components/common/nav-sidemenu.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
+import Image from 'next/image';
+import { CircleUserRound } from 'lucide-react';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import { useTransition } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { logout } from '@/app/action/user';
+import { toast } from 'sonner';
+import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
+
+interface Props {
+  userAvatar: string | null;
+}
+
+export default function NavSideMenu({ userAvatar }: Props) {
+  const [isPending, startTrasition] = useTransition();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const Logout = async () => {
+    startTrasition(async () => {
+      const action = await logout();
+      if (!action.success) {
+        toast.error(action.message);
+        return;
+      }
+      router.replace('/');
+    });
+  };
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <div className="relative flex items-center w-[35px] h-[35px] overflow-hidden rounded-3xl bg-white_light shadow-md group transition-all hover:w-[70px] duration-300 ease-in-out">
+          <div className="flex items-center gap-1 transition-transform duration-300 ease-in-out">
+            <Avatar className="size-[35px]">
+              <AvatarImage
+                src={userAvatar || '/default-profile-image.png'}
+                alt="user-avatar"
+                sizes="(max-width: 768px) 100vw"
+                style={{ objectFit: 'cover' }}
+              />
+              <AvatarFallback className="flex items-center justify-center">
+                <Image
+                  src="/default-profile-image.png"
+                  width={35}
+                  height={35}
+                  alt="default-profile"
+                  priority
+                />
+              </AvatarFallback>
+            </Avatar>
+          </div>
+          <button
+            type="button"
+            className="absolute right-0 top-0 flex items-center justify-center w-[35px] h-[35px] opacity-0 group-hover:opacity-100 transition-opacity duration-300 ease-in-out"
+            aria-label="profile"
+          >
+            <CircleUserRound className="size-5" />
+          </button>
+        </div>
+      </SheetTrigger>
+      <SheetContent className="border-none bg-opacity-90 bg-white_light" side="left">
+        <SheetTitle>메뉴</SheetTitle>
+        <Link
+          href="/profile"
+          className={cn(
+            pathname === '/profile' && 'bg-gray-200',
+            'flex items-center justify-center w-full text-black hover:bg-gray-200',
+          )}
+        >
+          프로필
+        </Link>
+        <button
+          disabled={isPending}
+          onClick={Logout}
+          type="button"
+          className="flex items-center justify-center w-full text-black hover:bg-gray-200"
+        >
+          로그아웃
+        </button>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      {children}
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -21,7 +21,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed w-screen tall:w-[420px] h-screen top-0 tall:left-[calc(50vw-10px)] z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
@@ -38,7 +38,7 @@ const sheetVariants = cva(
         top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
         bottom:
           'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
-        left: 'inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
+        left: 'fixed w-screen w-[250px] h-screen top-0 tall:left-[calc(50vw-10px)] h-full border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left',
         right:
           'inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
       },
@@ -62,7 +62,7 @@ const SheetContent = React.forwardRef<
     <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
       {children}
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" />
+        <X className="h-6 w-6" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,19 +1,19 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as SheetPrimitive from "@radix-ui/react-dialog"
-import { cva, type VariantProps } from "class-variance-authority"
-import { X } from "lucide-react"
+import * as React from 'react';
+import * as SheetPrimitive from '@radix-ui/react-dialog';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { X } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Sheet = SheetPrimitive.Root
+const Sheet = SheetPrimitive.Root;
 
-const SheetTrigger = SheetPrimitive.Trigger
+const SheetTrigger = SheetPrimitive.Trigger;
 
-const SheetClose = SheetPrimitive.Close
+const SheetClose = SheetPrimitive.Close;
 
-const SheetPortal = SheetPrimitive.Portal
+const SheetPortal = SheetPrimitive.Portal;
 
 const SheetOverlay = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Overlay>,
@@ -21,33 +21,33 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
+      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
     )}
     {...props}
     ref={ref}
   />
-))
-SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
   {
     variants: {
       side: {
-        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
         bottom:
-          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+          'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+        left: 'inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
         right:
-          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          'inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
       },
     },
     defaultVariants: {
-      side: "right",
+      side: 'right',
     },
-  }
-)
+  },
+);
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
@@ -56,14 +56,10 @@ interface SheetContentProps
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = 'right', className, children, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
-    <SheetPrimitive.Content
-      ref={ref}
-      className={cn(sheetVariants({ side }), className)}
-      {...props}
-    >
+    <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
       {children}
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" />
@@ -71,36 +67,25 @@ const SheetContent = React.forwardRef<
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>
   </SheetPortal>
-))
-SheetContent.displayName = SheetPrimitive.Content.displayName
+));
+SheetContent.displayName = SheetPrimitive.Content.displayName;
 
-const SheetHeader = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col space-y-2 text-center sm:text-left",
-      className
-    )}
-    {...props}
-  />
-)
-SheetHeader.displayName = "SheetHeader"
+function SheetHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
+  );
+}
+SheetHeader.displayName = 'SheetHeader';
 
-const SheetFooter = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
-    )}
-    {...props}
-  />
-)
-SheetFooter.displayName = "SheetFooter"
+function SheetFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+      {...props}
+    />
+  );
+}
+SheetFooter.displayName = 'SheetFooter';
 
 const SheetTitle = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Title>,
@@ -108,11 +93,11 @@ const SheetTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold text-foreground", className)}
+    className={cn('text-lg font-semibold text-foreground', className)}
     {...props}
   />
-))
-SheetTitle.displayName = SheetPrimitive.Title.displayName
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
 
 const SheetDescription = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Description>,
@@ -120,11 +105,11 @@ const SheetDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn('text-sm text-muted-foreground', className)}
     {...props}
   />
-))
-SheetDescription.displayName = SheetPrimitive.Description.displayName
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
 
 export {
   Sheet,
@@ -137,4 +122,4 @@ export {
   SheetFooter,
   SheetTitle,
   SheetDescription,
-}
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -6944,7 +6944,8 @@
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1109,7 +1109,8 @@
     },
     "node_modules/@radix-ui/react-dialog": {
       "version": "1.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.1.tgz",
+      "integrity": "sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
         "@radix-ui/react-compose-refs": "1.1.0",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,8 @@
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
+  // eslint-disable-next-line global-require
+  plugins: [require('tailwindcss-animate')],
   darkMode: ['class'],
   content: [
     './pages/**/*.{ts,tsx}',


### PR DESCRIPTION
<img width="1552" alt="스크린샷 2024-08-27 오후 4 31 26" src="https://github.com/user-attachments/assets/a02b16b0-34b6-4256-a170-aa850a28aa4a">
기존의 프로필 선택하면 드롭다운으로 메뉴가 나왔는데 사이드 메뉴로 변경해봤습니다.
그리고 shadcn에서 애니메이션을 넣어놨는데 적용이 안되서 tailwind-animate 설치해놨습니다. 데스크탑버전에서는 조금 이상한 부분이 있는데 모바일 버전에서는 문제없네요