### PR TITLE
온라인 유저 상태 리스트로 구현

### DIFF
--- a/app/(protected)/chat/[[...channel]]/_components/chat-online-list.tsx
+++ b/app/(protected)/chat/[[...channel]]/_components/chat-online-list.tsx
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import ChatOnlineUser from './chat-online-user';
+
+export default function ChatOnlineList({ users }: { users: any }) {
+  return (
+    <ul className="flex flex-col">
+      {users.map((item: any) => (
+        <li key={item.id}>
+          <ChatOnlineUser user={item} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/app/(protected)/chat/[[...channel]]/_components/chat-online-list.tsx
+++ b/app/(protected)/chat/[[...channel]]/_components/chat-online-list.tsx
@@ -1,14 +1,33 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { Menu } from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet';
 import ChatOnlineUser from './chat-online-user';
 
 export default function ChatOnlineList({ users }: { users: any }) {
   return (
-    <ul className="flex flex-col">
-      {users.map((item: any) => (
-        <li key={item.id}>
-          <ChatOnlineUser user={item} />
-        </li>
-      ))}
-    </ul>
+    <Sheet>
+      <SheetTrigger asChild>
+        <div className="w-8 h-8 flex justify-center items-center">
+          <Menu className="cursor-pointer" />
+        </div>
+      </SheetTrigger>
+      <SheetContent className="border-none bg-opacity-90 bg-white_light" side="left">
+        <SheetTitle>접속 유저</SheetTitle>
+        <SheetDescription aria-describedby={undefined} />
+        <ul className="flex flex-col mt-2 gap-2">
+          {users.map((item: any) => (
+            <li key={item.id}>
+              <ChatOnlineUser user={item} />
+            </li>
+          ))}
+        </ul>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/app/(protected)/chat/[[...channel]]/_components/chat-online-user.tsx
+++ b/app/(protected)/chat/[[...channel]]/_components/chat-online-user.tsx
@@ -4,7 +4,7 @@ import { Circle } from 'lucide-react';
 export default function ChatOnlineUser({ user }: { user: any }) {
   return (
     <div className="flex items-center">
-      <Circle className="mr-1" size={8} fill="#01FE19" color="#01FE19" />
+      <Circle className="mr-2" size={8} fill="#01FE19" color="#01FE19" />
       {user.data.fullName}
     </div>
   );

--- a/app/(protected)/chat/[[...channel]]/_components/chat-online-user.tsx
+++ b/app/(protected)/chat/[[...channel]]/_components/chat-online-user.tsx
@@ -1,0 +1,11 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Circle } from 'lucide-react';
+
+export default function ChatOnlineUser({ user }: { user: any }) {
+  return (
+    <div className="flex items-center">
+      <Circle className="mr-1" size={8} fill="#01FE19" color="#01FE19" />
+      {user.data.fullName}
+    </div>
+  );
+}

--- a/app/(protected)/chat/[[...channel]]/_components/chat-page.tsx
+++ b/app/(protected)/chat/[[...channel]]/_components/chat-page.tsx
@@ -11,12 +11,11 @@ interface Props {
 }
 
 export default function ChatPage({ channel, user }: Props) {
-  // 👉 Instantiate Ably client
   const client = new Realtime({
     key: '9bHIxw.wgXGGA:wE33mIt3P8z80cfkKZumcqb6NPL9AbQUKU_SZZ1oZ3M',
     clientId: user.id,
   });
-  const channelName = `chat:${channel}`;
+  const channelName = `chat:${channel[0]}`;
 
   return (
     <AblyProvider client={client}>

--- a/app/(protected)/chat/[[...channel]]/_components/chat-page.tsx
+++ b/app/(protected)/chat/[[...channel]]/_components/chat-page.tsx
@@ -8,9 +8,10 @@ import Chat from './chat';
 interface Props {
   channel: string;
   user: User;
+  activityTitle: string;
 }
 
-export default function ChatPage({ channel, user }: Props) {
+export default function ChatPage({ channel, user, activityTitle }: Props) {
   const client = new Realtime({
     key: '9bHIxw.wgXGGA:wE33mIt3P8z80cfkKZumcqb6NPL9AbQUKU_SZZ1oZ3M',
     clientId: user.id,
@@ -20,7 +21,7 @@ export default function ChatPage({ channel, user }: Props) {
   return (
     <AblyProvider client={client}>
       <ChannelProvider channelName={channelName}>
-        <Chat channelName={channelName} user={user} />
+        <Chat channelName={channelName} user={user} activityTitle={activityTitle} />
       </ChannelProvider>
     </AblyProvider>
   );

--- a/app/(protected)/chat/[[...channel]]/_components/chat.tsx
+++ b/app/(protected)/chat/[[...channel]]/_components/chat.tsx
@@ -2,7 +2,7 @@
 
 'use client';
 
-import { useChannel } from 'ably/react';
+import { useChannel, usePresence, usePresenceListener } from 'ably/react';
 import { useReducer, useEffect, useRef } from 'react';
 import { User } from '@/type';
 import MessageInput from './message-input';
@@ -28,6 +28,8 @@ export default function Chat({ channelName, user }: Props) {
   const [messages, dispatch] = useReducer(reducer, []);
   const { channel, publish } = useChannel(channelName, dispatch);
   const scrollRef = useRef<HTMLDivElement>(null);
+  usePresence(channelName, { fullName: user.nickname });
+  const { presenceData } = usePresenceListener(channelName);
 
   const publishMessage = (text: string) => {
     publish({

--- a/app/(protected)/chat/[[...channel]]/_components/chat.tsx
+++ b/app/(protected)/chat/[[...channel]]/_components/chat.tsx
@@ -5,12 +5,15 @@
 import { useChannel, usePresence, usePresenceListener } from 'ably/react';
 import { useReducer, useEffect, useRef } from 'react';
 import { User } from '@/type';
+import BackButton from '@/components/common/back-button';
 import MessageInput from './message-input';
 import MessageList from './message-list';
+import ChatOnlineList from './chat-online-list';
 
 interface Props {
   channelName: string;
   user: User;
+  activityTitle: string;
 }
 
 const ADD = 'ADD';
@@ -24,7 +27,7 @@ const reducer = (prev: any, event: any) => {
   }
 };
 
-export default function Chat({ channelName, user }: Props) {
+export default function Chat({ channelName, user, activityTitle }: Props) {
   const [messages, dispatch] = useReducer(reducer, []);
   const { channel, publish } = useChannel(channelName, dispatch);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -62,6 +65,13 @@ export default function Chat({ channelName, user }: Props) {
 
   return (
     <>
+      <div className="tall:sticky fixed left-0 top-0 right-0 p-3.5 z-30 border">
+        <div className="flex items-center justify-between">
+          <BackButton />
+          <p className="font-semibold">{activityTitle}</p>
+          <ChatOnlineList users={presenceData} />
+        </div>
+      </div>
       <div className="overflow-y-scroll p-5 pb-0 h-[calc(100vh-64px-66px)] bg-white_light">
         <p className="text-xs text-center text-gray-400">
           ※ 24시간이 지난 대화는 저장되지 않습니다!

--- a/app/(protected)/chat/[[...channel]]/page.tsx
+++ b/app/(protected)/chat/[[...channel]]/page.tsx
@@ -1,5 +1,4 @@
 import { getCurrentUser } from '@/app/data/user';
-import BackButton from '@/components/common/back-button';
 import { getActivityById } from '@/app/data/activity';
 import ChatPage from './_components/chat-page';
 
@@ -7,15 +6,5 @@ export default async function Page({ params }: { params: { channel: string } }) 
   const user = await getCurrentUser();
   const activity = await getActivityById(params.channel[0]);
 
-  return (
-    <>
-      <div className="tall:sticky fixed left-0 top-0 right-0 p-3.5 z-30 border">
-        <div className="flex items-center justify-between">
-          <BackButton />
-          <p className="font-semibold">{activity.title}</p>
-        </div>
-      </div>
-      <ChatPage channel={params.channel} user={user} />
-    </>
-  );
+  return <ChatPage channel={params.channel} user={user} activityTitle={activity.title} />;
 }


### PR DESCRIPTION
<img width="1552" alt="스크린샷 2024-08-29 오전 9 55 33" src="https://github.com/user-attachments/assets/df770dcd-61a9-4aeb-b41b-cd26c0a288b7">
해당 데이터를 사용하려면 구조적인 수정이 필요해서 채팅컴포넌트의 구조 수정을 해뒀고 메뉴로 햄버거 버튼 추가했습니다.
<img width="1552" alt="스크린샷 2024-08-29 오전 9 55 36" src="https://github.com/user-attachments/assets/e4630706-865e-4f81-963c-60a5ac102aac">
버튼 클릭시 접속 유저 리스트가 표시되도록 했습니다. 실시간으로 유저가 들어오고 나가는게 표시되는지는 테스트 해봐야 할것 같네요