### PR TITLE
약속 신청 피드백 추가

### DIFF
--- a/app/(protected)/(detail)/activity/[activityId]/_components/promise-request-form.tsx
+++ b/app/(protected)/(detail)/activity/[activityId]/_components/promise-request-form.tsx
@@ -8,7 +8,13 @@ import formatDateRange from '@/utils/formatDateRange';
 import { useState, useTransition } from 'react';
 import { toast } from 'sonner';
 
-export default function PromiseRequestForm({ activity }: { activity: ActivityWithRequest }) {
+export default function PromiseRequestForm({
+  activity,
+  currentUser,
+}: {
+  activity: ActivityWithRequest;
+  currentUser: string;
+}) {
   const { startDate, endDate, id, maximumCount, activityRequests } = activity;
   const [isPending, startTransition] = useTransition();
   const [isDisabled, setIsDisabled] = useState(!!activityRequests[0]);
@@ -34,14 +40,16 @@ export default function PromiseRequestForm({ activity }: { activity: ActivityWit
         <p className="text-sm text-white">최대 인원 {maximumCount}명</p>
         <p className="text-xs text-white">{formatDate}</p>
       </div>
-      <Button
-        type="button"
-        className="px-4 py-2 text-sm font-semibold text-white border border-none rounded-md bg-primary hover:bg-primary_dark"
-        onClick={applyActivity}
-        disabled={isPending || activityStatus || isDisabled}
-      >
-        {isDisabled ? '약속 요청함' : '약속잡기'}
-      </Button>
+      {activity.userId !== currentUser && (
+        <Button
+          type="button"
+          className="px-4 py-2 text-sm font-semibold text-white border border-none rounded-md bg-primary hover:bg-primary_dark"
+          onClick={applyActivity}
+          disabled={isPending || activityStatus || isDisabled}
+        >
+          {isDisabled ? '약속 요청함' : '약속잡기'}
+        </Button>
+      )}
     </div>
   );
 }

--- a/app/(protected)/(detail)/activity/[activityId]/_components/promise-request-form.tsx
+++ b/app/(protected)/(detail)/activity/[activityId]/_components/promise-request-form.tsx
@@ -3,18 +3,15 @@
 import { createActivityRequest } from '@/app/action/activity-request';
 import { requestMail } from '@/app/action/mail';
 import { Button } from '@/components/ui/button';
-import { ActivityWithUserAndFavorite } from '@/type';
+import { ActivityWithRequest } from '@/type';
 import formatDateRange from '@/utils/formatDateRange';
-import { useTransition } from 'react';
+import { useState, useTransition } from 'react';
 import { toast } from 'sonner';
 
-export default function PromiseRequestForm({
-  activity,
-}: {
-  activity: ActivityWithUserAndFavorite;
-}) {
-  const { startDate, endDate, id, maximumCount } = activity;
+export default function PromiseRequestForm({ activity }: { activity: ActivityWithRequest }) {
+  const { startDate, endDate, id, maximumCount, activityRequests } = activity;
   const [isPending, startTransition] = useTransition();
+  const [isDisabled, setIsDisabled] = useState(!!activityRequests[0]);
   const formatDate = formatDateRange({ startDateString: startDate, endDateString: endDate });
   const nowDate = new Date();
   const activityStatus = endDate < nowDate;
@@ -23,6 +20,7 @@ export default function PromiseRequestForm({
     startTransition(async () => {
       const result = await createActivityRequest(id);
       toast.message(result.message);
+      setIsDisabled(true);
       if (result.success) {
         const request = await requestMail(activity);
         toast.message(request.message);
@@ -40,9 +38,9 @@ export default function PromiseRequestForm({
         type="button"
         className="px-4 py-2 text-sm font-semibold text-white border border-none rounded-md bg-primary hover:bg-primary_dark"
         onClick={applyActivity}
-        disabled={isPending || activityStatus}
+        disabled={isPending || activityStatus || isDisabled}
       >
-        약속잡기
+        {isDisabled ? '약속 요청함' : '약속잡기'}
       </Button>
     </div>
   );

--- a/app/(protected)/(detail)/activity/[activityId]/page.tsx
+++ b/app/(protected)/(detail)/activity/[activityId]/page.tsx
@@ -1,6 +1,7 @@
 import PromiseRequestForm from '@/app/(protected)/(detail)/activity/[activityId]/_components/promise-request-form';
 import { getActivityById } from '@/app/data/activity';
 import DetailContent from '@/app/(protected)/(detail)/activity/[activityId]/_components/detail-content';
+import { getCurrentUserId } from '@/app/data/user';
 
 interface Params {
   activityId: string;
@@ -8,11 +9,12 @@ interface Params {
 
 export default async function Page({ params }: { params: Params }) {
   const activity = await getActivityById(params.activityId);
+  const currentUser = await getCurrentUserId();
 
   return (
     <div>
       <DetailContent detail={activity} />
-      <PromiseRequestForm activity={activity} />
+      <PromiseRequestForm activity={activity} currentUser={currentUser} />
     </div>
   );
 }

--- a/app/(protected)/(user)/dashboard/my-chat/_components/channel.tsx
+++ b/app/(protected)/(user)/dashboard/my-chat/_components/channel.tsx
@@ -1,11 +1,11 @@
-import { ActivityWithFavoriteAndCount } from '@/type';
+import { ActivityWithUserAndRequest } from '@/type';
 import formatDateRange from '@/utils/formatDateRange';
 import { User } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 
 interface Props {
-  activity: ActivityWithFavoriteAndCount;
+  activity: ActivityWithUserAndRequest;
 }
 
 export default function Channel({ activity }: Props) {
@@ -31,7 +31,9 @@ export default function Channel({ activity }: Props) {
             <p>{dateRange}</p>
             <div className="flex items-center gap-2">
               <User width={14} height={14} />
-              <p className="text-sm font-bold">{activity.maximumCount}명</p>
+              <p className="text-sm font-bold">
+                {activity.activityRequests.length} / {activity.maximumCount} 명
+              </p>
             </div>
           </div>
         </div>

--- a/app/(protected)/(user)/dashboard/my-chat/_components/chat-channel-list.tsx
+++ b/app/(protected)/(user)/dashboard/my-chat/_components/chat-channel-list.tsx
@@ -4,19 +4,19 @@
 
 import React, { useCallback, useState, useEffect, useTransition } from 'react';
 import useInfiniteScroll from '@/hooks/useInfiniteScroll';
-import { ActivityWithFavoriteAndCount } from '@/type';
+import { ActivityWithUserAndRequest } from '@/type';
 import Spinner from '@/components/ui/spinner';
 import Image from 'next/image';
 import getMyChat from '@/app/data/chat';
 import Channel from './channel';
 
 interface Props {
-  myActivities: ActivityWithFavoriteAndCount[];
+  myActivities: ActivityWithUserAndRequest[];
   activityCursorId: string | null;
 }
 
 export default function ChatChannelList({ myActivities, activityCursorId }: Props) {
-  const [activityList, setActivityList] = useState<ActivityWithFavoriteAndCount[]>([]);
+  const [activityList, setActivityList] = useState<ActivityWithUserAndRequest[]>([]);
   const [cursorId, setCursorId] = useState<string | null>('');
   const [isPending, startTransition] = useTransition();
 

--- a/app/(protected)/(user)/dashboard/promised-list/_components/promised-list-card.tsx
+++ b/app/(protected)/(user)/dashboard/promised-list/_components/promised-list-card.tsx
@@ -23,7 +23,7 @@ export default function PromisedListCard({ promisedActivity }: Props) {
   const approve: MouseEventHandler = (e) => {
     e.preventDefault();
     startTransition(async () => {
-      const action = await approveActivityRequest(id);
+      const action = await approveActivityRequest(id, activity.id);
       if (!action.success) {
         toast.error(action.message);
         return;

--- a/app/action/activity-request.ts
+++ b/app/action/activity-request.ts
@@ -51,8 +51,23 @@ export const createActivityRequest = async (
 
 export const approveActivityRequest = async (
   requestId: string,
+  activityId: string,
 ): Promise<ActionType<ActivityRequest>> => {
   try {
+    const approvedRequest = await db.activity.findUnique({
+      where: { id: activityId },
+      include: {
+        activityRequests: { where: { status: 'APPROVE' } },
+      },
+    });
+
+    if (
+      approvedRequest &&
+      approvedRequest.activityRequests.length === approvedRequest.maximumCount
+    ) {
+      return { success: false, message: '최대 인원 이상 요청을 수락할 수 없습니다.' };
+    }
+
     const activityRequest = await db.activityRequest.update({
       where: { id: requestId },
       data: { status: 'APPROVE' },

--- a/app/data/activity-request.ts
+++ b/app/data/activity-request.ts
@@ -24,7 +24,7 @@ export const getMySentRequests = async ({
       skip: cursor ? 1 : 0,
       take,
       orderBy: {
-        id: 'asc',
+        createdAt: 'desc',
       },
     });
 

--- a/app/data/activity.ts
+++ b/app/data/activity.ts
@@ -39,7 +39,7 @@ export const getMyActivities = async ({
       cursor: cursor ? { id: cursor } : undefined,
       skip: cursor ? 1 : 0,
       orderBy: {
-        createdAt: 'asc',
+        createdAt: 'desc',
       },
     });
 

--- a/app/data/activity.ts
+++ b/app/data/activity.ts
@@ -5,8 +5,8 @@ import db from '@/lib/db';
 import {
   ActivityWithUser,
   ActivityWithUserAndFavoCount,
-  ActivityWithUserAndFavorite,
   ActivityWithFavoriteAndCount,
+  ActivityWithRequest,
 } from '@/type';
 import { RequestStatus } from '@prisma/client';
 
@@ -173,7 +173,7 @@ export const getActivities = async ({
   }
 };
 
-export const getActivityById = async (id: string): Promise<ActivityWithUserAndFavorite> => {
+export const getActivityById = async (id: string): Promise<ActivityWithRequest> => {
   const userId = await getCurrentUserId();
   try {
     const activity = await db.activity.findUnique({
@@ -202,6 +202,7 @@ export const getActivityById = async (id: string): Promise<ActivityWithUserAndFa
             favorites: true,
           },
         },
+        activityRequests: { where: { requestUserId: userId } },
       },
     });
 

--- a/app/data/chat.ts
+++ b/app/data/chat.ts
@@ -2,7 +2,7 @@
 
 import { getCurrentUserId } from '@/app/data/user';
 import db from '@/lib/db';
-import { ActivityWithFavoriteAndCount } from '@/type';
+import { ActivityWithUserAndRequest } from '@/type';
 
 const getMyChat = async ({
   cursor,
@@ -10,23 +10,27 @@ const getMyChat = async ({
 }: {
   cursor?: string;
   take?: number;
-}): Promise<{ activities: ActivityWithFavoriteAndCount[]; cursorId: string | null }> => {
+}): Promise<{ activities: ActivityWithUserAndRequest[]; cursorId: string | null }> => {
   const userId = await getCurrentUserId();
   const nowDate = new Date();
 
   try {
-    const myActivities = await db.activity.findMany({
+    const myChat = await db.activity.findMany({
       where: { userId, endDate: { gte: nowDate } },
       include: {
-        _count: {
-          select: { favorites: true },
-        },
-        favorites: {
-          where: {
-            userId,
-          },
+        user: {
           select: {
             id: true,
+            nickname: true,
+            email: true,
+            image: true,
+            tags: true,
+            createdAt: true,
+          },
+        },
+        activityRequests: {
+          where: {
+            status: 'APPROVE',
           },
         },
       },
@@ -38,16 +42,10 @@ const getMyChat = async ({
       },
     });
 
-    const lastActivity = myActivities[myActivities.length - 1];
-    const cursorId = lastActivity ? lastActivity.id : null;
+    const lastChat = myChat[myChat.length - 1];
+    const cursorId = lastChat ? lastChat.id : null;
 
-    // Map over activities and add `isFavo` property
-    const activitiesWithFavo = myActivities.map((activity) => {
-      const isFavorite = activity.favorites.length > 0;
-      return { ...activity, isFavorite };
-    });
-
-    return { activities: activitiesWithFavo, cursorId };
+    return { activities: myChat, cursorId };
   } catch (error) {
     throw new Error('활동을 가져오는 중에 에러가 발생하였습니다.');
   }

--- a/app/data/chat.ts
+++ b/app/data/chat.ts
@@ -38,7 +38,7 @@ const getMyChat = async ({
       cursor: cursor ? { id: cursor } : undefined,
       skip: cursor ? 1 : 0,
       orderBy: {
-        createdAt: 'asc',
+        createdAt: 'desc',
       },
     });
 

--- a/type.ts
+++ b/type.ts
@@ -38,6 +38,7 @@ export type ActivityWithUserAndFavorite = ActivityWithFavoCount & {
 export type ActivityWithRequest = ActivityWithUserAndFavorite & {
   activityRequests: ActivityRequest[];
 };
+export type ActivityWithUserAndRequest = ActivityWithUser & { activityRequests: ActivityRequest[] };
 
 export type ActivityWithFavoriteAndCount = Activity & {
   isFavorite: boolean;

--- a/type.ts
+++ b/type.ts
@@ -35,6 +35,10 @@ export type ActivityWithUser = Activity & { user: User };
 export type ActivityWithUserAndFavorite = ActivityWithFavoCount & {
   isFavorite: boolean;
 };
+export type ActivityWithRequest = ActivityWithUserAndFavorite & {
+  activityRequests: ActivityRequest[];
+};
+
 export type ActivityWithFavoriteAndCount = Activity & {
   isFavorite: boolean;
 } & {


### PR DESCRIPTION
기존 로직에서는 버튼을 눌러야 약속 요청 여부를 알수 있었는데 데이터 불러올때 request까지 가져오도록 했습니다.
<img width="1552" alt="스크린샷 2024-09-04 오전 10 46 16" src="https://github.com/user-attachments/assets/5929ae0d-c28b-49e0-a9ea-64d52a4eb40d">
이미 요청을 보낸적이 있으면 텍스트 바뀌고 버튼 disabled처리 했습니다.
그리고 등록한 유저일때도 클릭이 가능했는데 아예 버튼 없애버렸습니다.
<img width="1552" alt="스크린샷 2024-09-04 오전 10 51 52" src="https://github.com/user-attachments/assets/15a51155-2f98-4378-b895-27a61968d1ee">
추가적으로 채팅 리스트에 참여한 인원 표시가 안되서 request활용해서 인원 추가해놨습니다.
<img width="1552" alt="스크린샷 2024-09-04 오전 10 45 55" src="https://github.com/user-attachments/assets/408bfea4-c992-40ae-a009-b4fb400b35cd">
