### PR TITLE
date-fns 위치 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
         "date-fns": "^3.6.0",
+        "date-fns-tz": "^3.1.3",
         "embla-carousel-autoplay": "^8.1.7",
         "embla-carousel-react": "^8.1.7",
         "lucide-react": "^0.408.0",
@@ -3113,6 +3114,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.1.3.tgz",
+      "integrity": "sha512-ZfbMu+nbzW0mEzC8VZrLiSWvUIaI3aRHeq33mTe7Y38UctKukgqPR4nTDwcwS4d64Gf8GghnVsroBuMY3eiTeA==",
+      "peerDependencies": {
+        "date-fns": "^3.0.0"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
     "date-fns": "^3.6.0",
+    "date-fns-tz": "^3.1.3",
     "embla-carousel-autoplay": "^8.1.7",
     "embla-carousel-react": "^8.1.7",
     "lucide-react": "^0.408.0",

--- a/utils/formatDateRange.tsx
+++ b/utils/formatDateRange.tsx
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 
 const formatDateRange = ({
   startDateString,
@@ -7,8 +7,8 @@ const formatDateRange = ({
   startDateString: Date;
   endDateString: Date;
 }) => {
-  const formattedStartDate = format(startDateString, 'yyyy.MM.dd');
-  const formattedEndDate = format(endDateString, 'yyyy.MM.dd');
+  const formattedStartDate = formatInTimeZone(startDateString, 'Asia/Seoul', 'yyyy.MM.dd');
+  const formattedEndDate = formatInTimeZone(endDateString, 'Asia/Seoul', 'yyyy.MM.dd');
 
   return `${formattedStartDate} ~ ${formattedEndDate}`;
 };


### PR DESCRIPTION
date-fns의 기본 위치 설정이 미국으로 되어있어서 서버와 클라이언트 사이에 차이가 있습니다.
그래서 date-fns-tz설치해서 format설정에 시간대를 aisa/seoul로 변경했습니다. 이러면 format하는 과정에서 시간 기준이 클라이언트와 서버가 일치해서 문제 없을 겁니다.