### PR TITLE
요청 상태 표시, revalidate 수정

### DIFF
--- a/app/(protected)/(detail)/activity/[activityId]/_components/promise-request-form.tsx
+++ b/app/(protected)/(detail)/activity/[activityId]/_components/promise-request-form.tsx
@@ -5,7 +5,7 @@ import { requestMail } from '@/app/action/mail';
 import { Button } from '@/components/ui/button';
 import { ActivityWithRequest } from '@/type';
 import formatDateRange from '@/utils/formatDateRange';
-import { useState, useTransition } from 'react';
+import { useEffect, useState, useTransition } from 'react';
 import { toast } from 'sonner';
 
 export default function PromiseRequestForm({
@@ -18,9 +18,10 @@ export default function PromiseRequestForm({
   const { startDate, endDate, id, maximumCount, activityRequests } = activity;
   const [isPending, startTransition] = useTransition();
   const [isDisabled, setIsDisabled] = useState(!!activityRequests[0]);
+  const [buttonStatus, setButtonStatus] = useState('');
   const formatDate = formatDateRange({ startDateString: startDate, endDateString: endDate });
   const nowDate = new Date();
-  const activityStatus = endDate < nowDate;
+  const deactivateActivity = endDate > nowDate;
 
   const applyActivity = () => {
     startTransition(async () => {
@@ -34,21 +35,49 @@ export default function PromiseRequestForm({
     });
   };
 
+  useEffect(() => {
+    if (!activityRequests[0]) {
+      setButtonStatus('약속잡기');
+    } else {
+      switch (activityRequests[0].status) {
+        case 'APPROVE':
+          setButtonStatus('수락됨');
+          break;
+        case 'PENDING':
+          setButtonStatus('대기중');
+          break;
+        case 'REJECT':
+          setButtonStatus('거절됨');
+          break;
+        default:
+          setButtonStatus('약속잡기');
+      }
+    }
+  }, [activityRequests]);
+
   return (
     <div className="tall:sticky fixed inset-x-0 bottom-0 w-full tall:max-w-[420px] h-20 bg-[#1B1B1B] z-50 flex justify-between gap-8 items-center px-8 py-0">
-      <div className="flex flex-col items-center justify-between w-full gap-2">
-        <p className="text-sm text-white">최대 인원 {maximumCount}명</p>
-        <p className="text-xs text-white">{formatDate}</p>
-      </div>
-      {activity.userId !== currentUser && (
-        <Button
-          type="button"
-          className="px-4 py-2 text-sm font-semibold text-white border border-none rounded-md bg-primary hover:bg-primary_dark"
-          onClick={applyActivity}
-          disabled={isPending || activityStatus || isDisabled}
-        >
-          {isDisabled ? '약속 요청함' : '약속잡기'}
-        </Button>
+      {deactivateActivity ? (
+        <>
+          <div className="flex flex-col items-center justify-between w-full gap-2">
+            <p className="text-sm text-white">최대 인원 {maximumCount}명</p>
+            <p className="text-xs text-white">{formatDate}</p>
+          </div>
+          {activity.userId !== currentUser && (
+            <Button
+              type="button"
+              className="px-4 py-2 text-sm font-semibold text-white border border-none rounded-md bg-primary hover:bg-primary_dark"
+              onClick={applyActivity}
+              disabled={isPending || isDisabled}
+            >
+              {buttonStatus}
+            </Button>
+          )}
+        </>
+      ) : (
+        <div className="flex justify-center items-center w-full">
+          <p className="text-white text-sm font-semibold">기간이 지난 활동은 신청할 수 없습니다.</p>
+        </div>
       )}
     </div>
   );

--- a/app/(protected)/(user)/dashboard/my-activity/_components/activity-edit-form.tsx
+++ b/app/(protected)/(user)/dashboard/my-activity/_components/activity-edit-form.tsx
@@ -77,7 +77,7 @@ export default function ActivityEditForm({ activity, onClose }: Props) {
       }
       toast.success(action.message);
       onClose();
-      router.replace('/dashboard/my-activity');
+      router.refresh();
     });
   };
 

--- a/app/(protected)/(user)/dashboard/my-activity/_components/my-activity-card.tsx
+++ b/app/(protected)/(user)/dashboard/my-activity/_components/my-activity-card.tsx
@@ -8,6 +8,7 @@ import { ActivityWithFavoriteAndCount } from '@/type';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
 import DeleteAlertModal from '@/components/delete-alert-modal';
+import { useRouter } from 'next/navigation';
 import ActivityEditForm from './activity-edit-form';
 
 interface Props {
@@ -19,6 +20,7 @@ export default function MyActivityCard({ activity }: Props) {
   const dateRange = formatDateRange({ startDateString: startDate, endDateString: endDate });
   const [isPending, startTransition] = useTransition();
   const [isEditModalOpen, setEditModalOpen] = useState<boolean>(false);
+  const router = useRouter();
   const nowDate = new Date();
 
   const handleClickEditFormOpen: MouseEventHandler = (e) => {
@@ -35,6 +37,7 @@ export default function MyActivityCard({ activity }: Props) {
         return;
       }
       toast.success(action.message);
+      router.refresh();
     });
   };
 

--- a/app/action/activity.ts
+++ b/app/action/activity.ts
@@ -1,6 +1,5 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 import db from '@/lib/db';
 import { ActionType } from '@/type';
@@ -44,8 +43,6 @@ export const createActivity = async ({
     });
 
     if (!newActivity) return { success: false, message: '활동 생성에 실패하였습니다.' };
-
-    revalidatePath('/dashboard/my-activity');
 
     return {
       success: true,
@@ -114,7 +111,6 @@ export const deleteActivity = async (activityId: string): Promise<ActionType<Act
 
     if (!deletedActivity) return { success: false, message: '활동 삭제에 실패하였습니다.' };
 
-    revalidatePath('/my-activity', 'page');
     return { success: true, message: '활동 삭제에 성공하였습니다.' };
   } catch (error) {
     return { success: false, message: '활동 삭제 중에 에러가 발생하였습니다.' };

--- a/app/action/answer.ts
+++ b/app/action/answer.ts
@@ -28,7 +28,7 @@ export const createAnswer = async ({
 
     if (!newAnswer) return { success: false, message: '답변 생성에 실패하였습니다.' };
 
-    revalidatePath('/question-list');
+    revalidatePath(`/question/${questionId}`, 'page');
 
     return {
       success: true,
@@ -60,7 +60,7 @@ export const editAnswer = async ({
 
     if (!updatedAnswer) return { success: false, message: '답변 수정에 실패하였습니다.' };
 
-    revalidatePath('/question-list');
+    revalidatePath(`/question/${updatedAnswer.questionId}`, 'page');
 
     return {
       success: true,
@@ -80,7 +80,7 @@ export const deleteAnswer = async (answerId: string): Promise<ActionType<Answer>
 
     if (!deletedAnswer) return { success: false, message: '답변 삭제에 실패하였습니다.' };
 
-    revalidatePath('/question-list');
+    revalidatePath(`/question/${deletedAnswer.questionId}`, 'page');
 
     return { success: true, message: '답변 삭제에 성공하였습니다.' };
   } catch (error) {

--- a/app/action/favorite.ts
+++ b/app/action/favorite.ts
@@ -4,7 +4,6 @@ import { getCurrentUserId } from '@/app/data/user';
 import db from '@/lib/db';
 import { ActionType } from '@/type';
 import { Favorite } from '@prisma/client';
-import { revalidatePath } from 'next/cache';
 
 const toggleFavorite = async (activityId: string): Promise<ActionType<Favorite>> => {
   const userId = await getCurrentUserId();
@@ -22,7 +21,6 @@ const toggleFavorite = async (activityId: string): Promise<ActionType<Favorite>>
           id: existingFavorite.id,
         },
       });
-      revalidatePath(`/${activityId}`);
 
       return { success: true, message: '즐겨찾기에서 삭제되었습니다.' };
     }
@@ -35,7 +33,6 @@ const toggleFavorite = async (activityId: string): Promise<ActionType<Favorite>>
     });
 
     if (!newFavorite) return { success: false, message: '즐겨찾기 추가에 실패하였습니다.' };
-    revalidatePath('/my-activity', 'page');
 
     return {
       success: true,

--- a/app/action/question.ts
+++ b/app/action/question.ts
@@ -28,7 +28,7 @@ export const createQuestion = async ({
 
     if (!question) return { success: false, message: '질문 생성에 실패하였습니다.' };
 
-    revalidatePath('/question-list');
+    revalidatePath('/question-list', 'page');
 
     return {
       success: true,
@@ -66,7 +66,7 @@ export const editQuestion = async ({
 
     if (!question) return { success: false, message: '질문 수정에 실패하였습니다.' };
 
-    revalidatePath('/question-list');
+    revalidatePath('/dashboard/my-question', 'page');
 
     return {
       success: true,
@@ -89,7 +89,8 @@ export const deleteQuestion = async (requestId: string): Promise<ActionType<Ques
 
     if (!question) return { success: false, message: '질문 삭제에 실패하였습니다.' };
 
-    revalidatePath('/my-qustion');
+    revalidatePath('/dashboard/my-question', 'page');
+
     return { success: true, message: '질문 삭제에 성공하였습니다.' };
   } catch (error) {
     return {

--- a/app/action/review.ts
+++ b/app/action/review.ts
@@ -43,7 +43,7 @@ const createReview = async ({
 
     if (!newReview) return { success: false, message: '리뷰 생성에 실패하였습니다.' };
 
-    revalidatePath('/reviews', 'page');
+    revalidatePath('/dashboard/reviews', 'page');
     return {
       success: true,
       message: '리뷰 생성에 성공하였습니다.',

--- a/app/data/activity-request.ts
+++ b/app/data/activity-request.ts
@@ -94,7 +94,7 @@ export const getMyReceivedRequests = async ({
     const lastRequest = requests[requests.length - 1];
     const cursorId = lastRequest ? lastRequest.id : null;
 
-    revalidatePath('/promised-list');
+    revalidatePath('/dashboard/promised-list');
 
     return { requests, cursorId };
   } catch (error) {


### PR DESCRIPTION
요청 상태에 따라 신청 여부 표시, 대기중, 거절, 수락으로 상태 표시하고 있습니다.
추가적으로 날짜 지난 활동은 아예 버튼 자체를 없애서 헷갈리지 않도록 만들어줬습니니다.
전체적으로 코드에 revalidate가 적용되어 있는데 경로가 예전 경로가 들어가 있어서 수정해줬습니다.
아직 refresh와 revalidate를 사용할 상황 케이스 확인이 부족해서 우선 경로 수정 위주로만 해놨습니다.