### PR TITLE
채팅 권한 구현

### DIFF
--- a/app/(protected)/(user)/dashboard/my-chat/_components/channel.tsx
+++ b/app/(protected)/(user)/dashboard/my-chat/_components/channel.tsx
@@ -15,7 +15,7 @@ export default function Channel({ activity }: Props) {
   });
 
   return (
-    <Link href={`/chat/${activity.id}`}>
+    <Link href={`/chat/${activity.id}`} scroll={false}>
       <div className="relative flex w-full gap-6 p-3 border rounded-lg">
         <div className="w-[110px] h-[110px] relative rounded-lg overflow-hidden flex-shrink-0">
           <Image

--- a/app/(protected)/(user)/dashboard/my-chat/_components/chat-channel-list.tsx
+++ b/app/(protected)/(user)/dashboard/my-chat/_components/chat-channel-list.tsx
@@ -7,7 +7,7 @@ import useInfiniteScroll from '@/hooks/useInfiniteScroll';
 import { ActivityWithUserAndRequest } from '@/type';
 import Spinner from '@/components/ui/spinner';
 import Image from 'next/image';
-import getMyChat from '@/app/data/chat';
+import { getMyChat } from '@/app/data/chat';
 import Channel from './channel';
 
 interface Props {

--- a/app/(protected)/(user)/dashboard/my-chat/page.tsx
+++ b/app/(protected)/(user)/dashboard/my-chat/page.tsx
@@ -1,6 +1,6 @@
 import { getCurrentUser } from '@/app/data/user';
 import { Suspense } from 'react';
-import getMyChat from '@/app/data/chat';
+import { getMyChat } from '@/app/data/chat';
 import Loading from '../loading';
 import ChatChannelList from './_components/chat-channel-list';
 

--- a/app/(protected)/chat/[channel]/_components/chat-online-list.tsx
+++ b/app/(protected)/chat/[channel]/_components/chat-online-list.tsx
@@ -1,5 +1,9 @@
+/* eslint-disable no-plusplus */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Menu } from 'lucide-react';
+
+'use client';
+
+import { Circle, Crown, Menu } from 'lucide-react';
 import {
   Sheet,
   SheetContent,
@@ -7,15 +11,28 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
-import { RequestWithReqUser } from '@/type';
+import { RequestWithReqUser, User } from '@/type';
+import { useEffect, useState } from 'react';
 import ChatOnlineUser from './chat-online-user';
 
 interface Props {
   member: RequestWithReqUser[];
-  users: any;
+  users: any[];
+  owner: User;
 }
 
-export default function ChatOnlineList({ users, member }: Props) {
+export default function ChatOnlineList({ users, member, owner }: Props) {
+  const [ownerConnected, setOwnerConnected] = useState(false);
+
+  useEffect(() => {
+    for (let i = 0; users.length > i; i++) {
+      if (users[i].clientId === owner.id) {
+        setOwnerConnected(true);
+        break;
+      }
+    }
+  }, [owner, users]);
+
   return (
     <Sheet>
       <SheetTrigger asChild>
@@ -27,9 +44,20 @@ export default function ChatOnlineList({ users, member }: Props) {
         <SheetTitle>접속 유저</SheetTitle>
         <SheetDescription aria-describedby={undefined} />
         <ul className="flex flex-col mt-2 gap-2">
+          <li>
+            <div className="flex items-center gap-2">
+              <Circle
+                size={8}
+                fill={ownerConnected ? '#01FE19' : '#848484'}
+                color={ownerConnected ? '#01FE19' : '#848484'}
+              />
+              {owner.nickname}
+              <Crown size={15} fill="#ffcf00" color="#ffcf00" />
+            </div>
+          </li>
           {member.map((item: RequestWithReqUser) => (
             <li key={item.id}>
-              <ChatOnlineUser user={item} />
+              <ChatOnlineUser user={item} connectedUser={users} />
             </li>
           ))}
         </ul>

--- a/app/(protected)/chat/[channel]/_components/chat-online-list.tsx
+++ b/app/(protected)/chat/[channel]/_components/chat-online-list.tsx
@@ -7,9 +7,15 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
+import { RequestWithReqUser } from '@/type';
 import ChatOnlineUser from './chat-online-user';
 
-export default function ChatOnlineList({ users }: { users: any }) {
+interface Props {
+  member: RequestWithReqUser[];
+  users: any;
+}
+
+export default function ChatOnlineList({ users, member }: Props) {
   return (
     <Sheet>
       <SheetTrigger asChild>
@@ -21,7 +27,7 @@ export default function ChatOnlineList({ users }: { users: any }) {
         <SheetTitle>접속 유저</SheetTitle>
         <SheetDescription aria-describedby={undefined} />
         <ul className="flex flex-col mt-2 gap-2">
-          {users.map((item: any) => (
+          {member.map((item: RequestWithReqUser) => (
             <li key={item.id}>
               <ChatOnlineUser user={item} />
             </li>

--- a/app/(protected)/chat/[channel]/_components/chat-online-user.tsx
+++ b/app/(protected)/chat/[channel]/_components/chat-online-user.tsx
@@ -1,11 +1,37 @@
+/* eslint-disable no-plusplus */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+'use client';
+
 import { RequestWithReqUser } from '@/type';
 import { Circle } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
-export default function ChatOnlineUser({ user }: { user: RequestWithReqUser }) {
+interface Props {
+  connectedUser: any[];
+  user: RequestWithReqUser;
+}
+
+export default function ChatOnlineUser({ user, connectedUser }: Props) {
+  const [isConnected, setIsConnected] = useState(false);
+
+  useEffect(() => {
+    for (let i = 0; connectedUser.length > i; i++) {
+      if (user.requestUser.id === connectedUser[i].clientId) {
+        setIsConnected(true);
+        break;
+      }
+    }
+  }, [connectedUser, user]);
+
   return (
     <div className="flex items-center">
-      <Circle className="mr-2" size={8} fill="#01FE19" color="#01FE19" />
+      <Circle
+        className="mr-2"
+        size={8}
+        fill={isConnected ? '#01FE19' : '#848484'}
+        color={isConnected ? '#01FE19' : '#848484'}
+      />
       {user.requestUser.nickname}
     </div>
   );

--- a/app/(protected)/chat/[channel]/_components/chat-online-user.tsx
+++ b/app/(protected)/chat/[channel]/_components/chat-online-user.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { RequestWithReqUser } from '@/type';
 import { Circle } from 'lucide-react';
 
-export default function ChatOnlineUser({ user }: { user: any }) {
+export default function ChatOnlineUser({ user }: { user: RequestWithReqUser }) {
   return (
     <div className="flex items-center">
       <Circle className="mr-2" size={8} fill="#01FE19" color="#01FE19" />
-      {user.data.fullName}
+      {user.requestUser.nickname}
     </div>
   );
 }

--- a/app/(protected)/chat/[channel]/_components/chat-page.tsx
+++ b/app/(protected)/chat/[channel]/_components/chat-page.tsx
@@ -10,9 +10,10 @@ interface Props {
   user: User;
   activityTitle: string;
   member: RequestWithReqUser[];
+  owner: User;
 }
 
-export default function ChatPage({ channel, user, activityTitle, member }: Props) {
+export default function ChatPage({ channel, user, activityTitle, member, owner }: Props) {
   const client = new Realtime({
     key: process.env.NEXT_PUBLIC_ABLY_KEY,
     clientId: user.id,
@@ -22,7 +23,13 @@ export default function ChatPage({ channel, user, activityTitle, member }: Props
   return (
     <AblyProvider client={client}>
       <ChannelProvider channelName={channelName}>
-        <Chat channelName={channelName} user={user} activityTitle={activityTitle} member={member} />
+        <Chat
+          channelName={channelName}
+          user={user}
+          activityTitle={activityTitle}
+          member={member}
+          owner={owner}
+        />
       </ChannelProvider>
     </AblyProvider>
   );

--- a/app/(protected)/chat/[channel]/_components/chat-page.tsx
+++ b/app/(protected)/chat/[channel]/_components/chat-page.tsx
@@ -2,16 +2,17 @@
 
 import { Realtime } from 'ably';
 import { AblyProvider, ChannelProvider } from 'ably/react';
-import { User } from '@/type';
+import { RequestWithReqUser, User } from '@/type';
 import Chat from './chat';
 
 interface Props {
   channel: string;
   user: User;
   activityTitle: string;
+  member: RequestWithReqUser[];
 }
 
-export default function ChatPage({ channel, user, activityTitle }: Props) {
+export default function ChatPage({ channel, user, activityTitle, member }: Props) {
   const client = new Realtime({
     key: process.env.NEXT_PUBLIC_ABLY_KEY,
     clientId: user.id,
@@ -21,7 +22,7 @@ export default function ChatPage({ channel, user, activityTitle }: Props) {
   return (
     <AblyProvider client={client}>
       <ChannelProvider channelName={channelName}>
-        <Chat channelName={channelName} user={user} activityTitle={activityTitle} />
+        <Chat channelName={channelName} user={user} activityTitle={activityTitle} member={member} />
       </ChannelProvider>
     </AblyProvider>
   );

--- a/app/(protected)/chat/[channel]/_components/chat-page.tsx
+++ b/app/(protected)/chat/[channel]/_components/chat-page.tsx
@@ -1,8 +1,12 @@
+/* eslint-disable no-plusplus */
+
 'use client';
 
 import { Realtime } from 'ably';
 import { AblyProvider, ChannelProvider } from 'ably/react';
 import { RequestWithReqUser, User } from '@/type';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import Chat from './chat';
 
 interface Props {
@@ -14,11 +18,29 @@ interface Props {
 }
 
 export default function ChatPage({ channel, user, activityTitle, member, owner }: Props) {
+  const router = useRouter();
   const client = new Realtime({
     key: process.env.NEXT_PUBLIC_ABLY_KEY,
     clientId: user.id,
   });
   const channelName = `chat:${channel}`;
+
+  useEffect(() => {
+    let acceptUser = false;
+    for (let i = 0; member.length > i; i++) {
+      if (member[i].requestUserId === user.id) {
+        acceptUser = true;
+        break;
+      }
+    }
+    if (user.id === owner.id) {
+      acceptUser = true;
+    }
+    if (!acceptUser) {
+      alert('접근 권한이 없는 채팅입니다. 채팅리스트로 이동해주세요.');
+      router.replace('/dashboard/my-chat');
+    }
+  }, [member, owner, router, user]);
 
   return (
     <AblyProvider client={client}>

--- a/app/(protected)/chat/[channel]/_components/chat.tsx
+++ b/app/(protected)/chat/[channel]/_components/chat.tsx
@@ -4,7 +4,7 @@
 
 import { useChannel, usePresence, usePresenceListener } from 'ably/react';
 import { useReducer, useEffect, useRef } from 'react';
-import { User } from '@/type';
+import { RequestWithReqUser, User } from '@/type';
 import BackButton from '@/components/common/back-button';
 import MessageInput from './message-input';
 import MessageList from './message-list';
@@ -14,6 +14,7 @@ interface Props {
   channelName: string;
   user: User;
   activityTitle: string;
+  member: RequestWithReqUser[];
 }
 
 const ADD = 'ADD';
@@ -27,7 +28,7 @@ const reducer = (prev: any, event: any) => {
   }
 };
 
-export default function Chat({ channelName, user, activityTitle }: Props) {
+export default function Chat({ channelName, user, activityTitle, member }: Props) {
   const [messages, dispatch] = useReducer(reducer, []);
   const { channel, publish } = useChannel(channelName, dispatch);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -69,7 +70,7 @@ export default function Chat({ channelName, user, activityTitle }: Props) {
         <div className="flex items-center justify-between">
           <BackButton />
           <p className="font-semibold">{activityTitle}</p>
-          <ChatOnlineList users={presenceData} />
+          <ChatOnlineList users={presenceData} member={member} />
         </div>
       </div>
       <div className="overflow-y-scroll p-5 pb-0 h-[calc(100vh-64px-66px)] bg-white_light">

--- a/app/(protected)/chat/[channel]/_components/chat.tsx
+++ b/app/(protected)/chat/[channel]/_components/chat.tsx
@@ -15,6 +15,7 @@ interface Props {
   user: User;
   activityTitle: string;
   member: RequestWithReqUser[];
+  owner: User;
 }
 
 const ADD = 'ADD';
@@ -28,7 +29,7 @@ const reducer = (prev: any, event: any) => {
   }
 };
 
-export default function Chat({ channelName, user, activityTitle, member }: Props) {
+export default function Chat({ channelName, user, activityTitle, member, owner }: Props) {
   const [messages, dispatch] = useReducer(reducer, []);
   const { channel, publish } = useChannel(channelName, dispatch);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -70,7 +71,7 @@ export default function Chat({ channelName, user, activityTitle, member }: Props
         <div className="flex items-center justify-between">
           <BackButton />
           <p className="font-semibold">{activityTitle}</p>
-          <ChatOnlineList users={presenceData} member={member} />
+          <ChatOnlineList users={presenceData} member={member} owner={owner} />
         </div>
       </div>
       <div className="overflow-y-scroll p-5 pb-0 h-[calc(100vh-64px-66px)] bg-white_light">

--- a/app/(protected)/chat/[channel]/page.tsx
+++ b/app/(protected)/chat/[channel]/page.tsx
@@ -12,6 +12,7 @@ export default async function Page({ params }: { params: { channel: string } }) 
       user={user}
       activityTitle={activity.title}
       member={activity.activityRequests}
+      owner={activity.user}
     />
   );
 }

--- a/app/(protected)/chat/[channel]/page.tsx
+++ b/app/(protected)/chat/[channel]/page.tsx
@@ -1,10 +1,17 @@
 import { getCurrentUser } from '@/app/data/user';
-import { getActivityById } from '@/app/data/activity';
+import { getChannelById } from '@/app/data/chat';
 import ChatPage from './_components/chat-page';
 
 export default async function Page({ params }: { params: { channel: string } }) {
   const user = await getCurrentUser();
-  const activity = await getActivityById(params.channel);
+  const activity = await getChannelById(params.channel);
 
-  return <ChatPage channel={params.channel} user={user} activityTitle={activity.title} />;
+  return (
+    <ChatPage
+      channel={params.channel}
+      user={user}
+      activityTitle={activity.title}
+      member={activity.activityRequests}
+    />
+  );
 }

--- a/app/data/chat.ts
+++ b/app/data/chat.ts
@@ -2,9 +2,9 @@
 
 import { getCurrentUserId } from '@/app/data/user';
 import db from '@/lib/db';
-import { ActivityWithUserAndRequest } from '@/type';
+import { ActivityWithUserAndRequest, ActivityWithUserandReqUser } from '@/type';
 
-const getMyChat = async ({
+export const getMyChat = async ({
   cursor,
   take = 10,
 }: {
@@ -51,4 +51,48 @@ const getMyChat = async ({
   }
 };
 
-export default getMyChat;
+export const getChannelById = async (id: string): Promise<ActivityWithUserandReqUser> => {
+  try {
+    const activity = await db.activity.findUnique({
+      where: { id },
+      include: {
+        user: {
+          select: {
+            id: true,
+            nickname: true,
+            email: true,
+            image: true,
+            tags: true,
+            createdAt: true,
+          },
+        },
+        activityRequests: {
+          where: { status: 'APPROVE' },
+          include: {
+            requestUser: {
+              select: {
+                id: true,
+                nickname: true,
+                email: true,
+                image: true,
+                tags: true,
+                createdAt: true,
+              },
+            },
+            activity: true,
+          },
+        },
+      },
+    });
+
+    if (!activity) {
+      throw new Error('활동을 찾을 수 없습니다.');
+    }
+
+    return {
+      ...activity,
+    };
+  } catch (error) {
+    throw new Error('활동을 가져오는 중에 에러가 발생하였습니다.');
+  }
+};

--- a/type.ts
+++ b/type.ts
@@ -27,6 +27,9 @@ export type RequestWithReqUserAndActivity = ActivityRequest & {
   requestUser: User;
   activity: Activity;
 };
+export type RequestWithReqUser = ActivityRequest & {
+  requestUser: User;
+};
 
 // Activity
 export type ActivityWithFavoCount = Activity & { _count: { favorites: number } };
@@ -39,6 +42,9 @@ export type ActivityWithRequest = ActivityWithUserAndFavorite & {
   activityRequests: ActivityRequest[];
 };
 export type ActivityWithUserAndRequest = ActivityWithUser & { activityRequests: ActivityRequest[] };
+export type ActivityWithUserandReqUser = ActivityWithUser & {
+  activityRequests: RequestWithReqUser[];
+};
 
 export type ActivityWithFavoriteAndCount = Activity & {
   isFavorite: boolean;


### PR DESCRIPTION
채팅에 어떤 유저들이 들어와 있는지 확인이 안되서
<img width="1552" alt="스크린샷 2024-09-06 오후 2 16 47" src="https://github.com/user-attachments/assets/ecce6d3c-7c1e-478a-9cca-a17eee6d2e8c">
기존의 접속 유저만 표시하던 사이드 메뉴에서 전체 리스트로 변경시켜줬습니다. 그리고 최상단에는 액티비티 생성한 길라가 왕관 표시와 함께 표시됩니다. 이것도 실시간 접속 유저 상태를 확인할 수 있도록 했습니다.
그리고 활동 id만 가지고 있으면 모든 유저가 채팅에 접근이 가능했는데
<img width="1552" alt="스크린샷 2024-09-06 오후 2 18 57" src="https://github.com/user-attachments/assets/fd69cd6c-80a2-4874-b193-fef1a8d67b53">
지금은 alert로 경고하고 대시보드의 채팅 리스트로 이동시켜줬습니다.