### PR TITLE
약속 신청 로직 수정, 인증 페이지 스타일 수정, 버튼 로딩 적용

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -3,19 +3,20 @@ import BackButton from '@/components/common/back-button';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="relative flex flex-col max-w-[420px] bg-white_light tall:w-[420px] h-[calc(100vh-68px)] gap-5 tall:gap-0">
+    <div className="relative flex flex-col max-w-[420px] bg-white_light tall:w-[420px] tall:h-screen h-[calc(100vh-68px)] gap-5 tall:gap-0">
       <div className="flex flex-col items-center w-full gap-5 top-0 pt-5">
         <div className="relative size-14">
           <Image fill src="/GilaLogo.png" alt="logo-to-home" style={{ objectFit: 'contain' }} />
         </div>
         <div>
-          <p className="text-3xl font-semibold">
-            <span className="font-bold text-primary">길라</span>에 오신 것을 환영합니다
+          <p className="text-3xl font-semibold text-center">
+            <span className="font-bold text-primary">길라</span>에 오신 것을
+            <br /> 환영합니다
             <span className="text-primary">.</span>
           </p>
         </div>
       </div>
-      <main className="w-full min-h-[calc(100vh-132px-68px)] overflow-y-scroll flex flex-col pb-20 tall:pb-0">
+      <main className="w-full flex flex-col pb-20 tall:pb-0 tall:h-[calc(100vh-168px-68px)] overflow-y-scroll pt-6">
         {children}
       </main>
       <div className="tall:sticky fixed bottom-0 p-4 border-t border-gray-300 left-0 w-screen bg-[#ffffff] tall:w-full">

--- a/app/(auth)/sign-in/_components/login-form.tsx
+++ b/app/(auth)/sign-in/_components/login-form.tsx
@@ -110,6 +110,7 @@ export default function LoginForm() {
           text="로그인"
           type="submit"
           disabled={isPending || !form.formState.isValid}
+          isPending={isPending}
         />
       </form>
     </Form>

--- a/app/(auth)/sign-up/_components/register-form.tsx
+++ b/app/(auth)/sign-up/_components/register-form.tsx
@@ -181,6 +181,7 @@ export default function RegisterForm() {
           text="회원가입"
           disabled={isPending || !form.formState.isValid || !validEmail}
           type="submit"
+          isPending={isPending}
         />
       </form>
     </Form>

--- a/app/(protected)/(detail)/activity/[activityId]/_components/promise-request-form.tsx
+++ b/app/(protected)/(detail)/activity/[activityId]/_components/promise-request-form.tsx
@@ -3,6 +3,7 @@
 import { createActivityRequest } from '@/app/action/activity-request';
 import { requestMail } from '@/app/action/mail';
 import { Button } from '@/components/ui/button';
+import REQUEST_STATUS from '@/constants/request';
 import { ActivityWithRequest } from '@/type';
 import formatDateRange from '@/utils/formatDateRange';
 import { useEffect, useState, useTransition } from 'react';
@@ -18,7 +19,7 @@ export default function PromiseRequestForm({
   const { startDate, endDate, id, maximumCount, activityRequests } = activity;
   const [isPending, startTransition] = useTransition();
   const [isDisabled, setIsDisabled] = useState(!!activityRequests[0]);
-  const [buttonStatus, setButtonStatus] = useState('');
+  const [buttonStatus, setButtonStatus] = useState(REQUEST_STATUS.DEFAULT);
   const formatDate = formatDateRange({ startDateString: startDate, endDateString: endDate });
   const nowDate = new Date();
   const deactivateActivity = endDate > nowDate;
@@ -27,6 +28,7 @@ export default function PromiseRequestForm({
     startTransition(async () => {
       const result = await createActivityRequest(id);
       toast.message(result.message);
+      setButtonStatus(REQUEST_STATUS.PENDING);
       setIsDisabled(true);
       if (result.success) {
         const request = await requestMail(activity);
@@ -35,24 +37,9 @@ export default function PromiseRequestForm({
     });
   };
 
-  // 이 부분은 form으로 개선이 필요해 보여서 버튼 적용은 추후에 진행해야 할 듯 합니다.
   useEffect(() => {
-    if (!activityRequests[0]) {
-      setButtonStatus('약속잡기');
-    } else {
-      switch (activityRequests[0].status) {
-        case 'APPROVE':
-          setButtonStatus('수락됨');
-          break;
-        case 'PENDING':
-          setButtonStatus('대기중');
-          break;
-        case 'REJECT':
-          setButtonStatus('거절됨');
-          break;
-        default:
-          setButtonStatus('약속잡기');
-      }
+    if (activityRequests[0]) {
+      setButtonStatus(REQUEST_STATUS[activityRequests[0].status]);
     }
   }, [activityRequests]);
 

--- a/app/(protected)/(main)/question-list/_components/question-form.tsx
+++ b/app/(protected)/(main)/question-list/_components/question-form.tsx
@@ -133,6 +133,7 @@ export default function QuestionForm() {
               type="submit"
               text="물어보기"
               disabled={isPending || !form.formState.isValid}
+              isPending={isPending}
             />
           </div>
         </div>

--- a/app/(protected)/(user)/dashboard/my-question/_components/my-question-card.tsx
+++ b/app/(protected)/(user)/dashboard/my-question/_components/my-question-card.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 /* eslint-disable no-underscore-dangle */
-import { Loader2, MessageCircle } from 'lucide-react';
-import React, { useTransition } from 'react';
+import { MessageCircle } from 'lucide-react';
+import { useTransition } from 'react';
 import { QuestionWithUserAndAnswers } from '@/type';
 import calculateDate from '@/utils/calculateData';
 import { deleteQuestion } from '@/app/action/question';
@@ -10,6 +10,7 @@ import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import MyQuestionKebab from '@/app/(protected)/(user)/dashboard/my-question/_components/my-question-kebab';
 import Link from 'next/link';
+import LoadingSpinner from '@/components/loading-spinner';
 
 interface Props {
   myQuestionItem: QuestionWithUserAndAnswers;
@@ -35,16 +36,7 @@ export default function MyQuestionCard({ myQuestionItem }: Props) {
   return (
     <Link href={`/question/${myQuestionItem.id}`}>
       <div className="relative">
-        {isPending && (
-          <div
-            className="absolute inset-0 z-10 flex items-center justify-center rounded-md cursor-not-allowed bg-black/50"
-            onClick={(e: React.MouseEvent<HTMLDivElement>) => {
-              e.preventDefault();
-            }}
-          >
-            <Loader2 className="w-8 h-8 animate-spin" />
-          </div>
-        )}
+        {isPending && <LoadingSpinner />}
         <Card className="flex flex-col items-start w-full p-0 overflow-hidden border border-gray-200 rounded-md shadow-md hover:shadow-lg">
           <CardHeader className="flex flex-row w-full gap-1 px-2 py-3">
             <CardTitle className="w-full text-2xl font-semibold truncate">

--- a/components/common/primary-CTA-button.tsx
+++ b/components/common/primary-CTA-button.tsx
@@ -4,7 +4,7 @@ import LoadingSpinner from '../loading-spinner';
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   text: string;
-  isPending: boolean;
+  isPending?: boolean;
 }
 
 export default function PrimaryCTAButton({ text, disabled, type, isPending }: Props) {

--- a/components/common/primary-CTA-button.tsx
+++ b/components/common/primary-CTA-button.tsx
@@ -1,18 +1,23 @@
 import { ButtonHTMLAttributes } from 'react';
 import { Button } from '@/components/ui/button';
+import LoadingSpinner from '../loading-spinner';
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   text: string;
+  isPending: boolean;
 }
 
-export default function PrimaryCTAButton({ text, disabled, type }: Props) {
+export default function PrimaryCTAButton({ text, disabled, type, isPending }: Props) {
   return (
-    <Button
-      disabled={disabled}
-      type={type}
-      className="w-full py-3 text-lg font-semibold text-white disabled:bg-primary_dark"
-    >
-      {text}
-    </Button>
+    <div className="relative">
+      {isPending && <LoadingSpinner />}
+      <Button
+        disabled={disabled}
+        type={type}
+        className="w-full py-3 text-lg font-semibold text-white disabled:bg-primary_dark"
+      >
+        {text}
+      </Button>
+    </div>
   );
 }

--- a/components/loading-spinner.tsx
+++ b/components/loading-spinner.tsx
@@ -1,0 +1,14 @@
+import { Loader } from 'lucide-react';
+
+export default function LoadingSpinner() {
+  return (
+    <div
+      className="absolute inset-0 z-10 flex items-center justify-center rounded-md cursor-not-allowed bg-gray-400/50"
+      onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+        e.preventDefault();
+      }}
+    >
+      <Loader className="w-8 h-8 animate-spin" />
+    </div>
+  );
+}

--- a/constants/request.ts
+++ b/constants/request.ts
@@ -1,0 +1,7 @@
+const REQUEST_STATUS = {
+  DEFAULT: '약속잡기',
+  PENDING: '대기중',
+  APPROVE: '수락됨',
+  REJECT: '거절됨',
+};
+export default REQUEST_STATUS;


### PR DESCRIPTION
기존의 약속 신청 로직에서 switch case로 텍스트를 넣어줬는데 비효율적이고 하드 코딩이라서 status 상수값 만들어서 동일한 동작 로직 구현해줬습니다.

인증 페이지 스타일이 좀 깨지는 문제가 있어서 해당 문제 해결했습니다.

로그인이나 회원가입 요청시에 버튼이 disabled만 됬는데 spinner 컴포넌트 구현해서 도입시켜놨습니다. 로딩 컴포넌트는 다른 페이지에서도 사용하면 좋을듯 하네욥