### PR TITLE
fix: 활동, 질문 리스트 캐싱 추가 및 생성시 revalidation 추가

### DIFF
--- a/app/(protected)/(main)/activity-list/page.tsx
+++ b/app/(protected)/(main)/activity-list/page.tsx
@@ -4,13 +4,40 @@ import MainCarousel from '@/app/(protected)/(main)/_components/main-carousel';
 import ActivityContainer from '@/app/(protected)/(main)/activity-list/_components/activity-container';
 import Link from 'next/link';
 import PlusDiv from '@/components/common/plus-div';
+import { unstable_cache } from 'next/cache';
+import { getCurrentUser } from '@/app/data/user';
+
+const getActivityWithCache = unstable_cache(
+  async ({
+    type,
+    location,
+    size,
+    tags,
+  }: {
+    type: Sort;
+    location?: string;
+    size: number;
+    tags: string[];
+  }) => {
+    const result = await getActivities({ type, location, size, tags });
+    return result;
+  },
+  ['activityList'],
+  { revalidate: 3600, tags: ['activityList'] },
+);
 
 export default async function Page({
   searchParams: { sort, location },
 }: {
   searchParams: { sort: Sort; location: string };
 }) {
-  const { activities, cursorId } = await getActivities({ type: sort, location, size: 5 });
+  const currentUser = await getCurrentUser();
+  const { activities, cursorId } = await getActivityWithCache({
+    type: sort,
+    location,
+    size: 5,
+    tags: currentUser.tags,
+  });
 
   return (
     <main className="relative">

--- a/app/(protected)/(main)/question-list/page.tsx
+++ b/app/(protected)/(main)/question-list/page.tsx
@@ -4,6 +4,26 @@ import QuestionList from '@/app/(protected)/(main)/question-list/_components/que
 import SortingDropdown from '@/components/sorting-dropdown';
 import { QUESTIONSORTS } from '@/constants/sort';
 import { QuestionSort } from '@/type';
+import { unstable_cache } from 'next/cache';
+
+const getQuestionWithCache = unstable_cache(
+  async ({
+    take,
+    order,
+    answerTake,
+    location,
+  }: {
+    take: number;
+    order: QuestionSort;
+    answerTake: number;
+    location?: string;
+  }) => {
+    const result = await getQuestions({ take, order, answerTake, location });
+    return result;
+  },
+  ['questionList'],
+  { revalidate: 3600, tags: ['questionList'] },
+);
 
 export default async function Page({
   searchParams,
@@ -11,7 +31,7 @@ export default async function Page({
   searchParams: { sort: QuestionSort; location: string };
 }) {
   const { sort, location } = searchParams;
-  const qusetions = await getQuestions({
+  const qusetions = await getQuestionWithCache({
     take: 7,
     order: sort,
     answerTake: 5,

--- a/app/action/activity.ts
+++ b/app/action/activity.ts
@@ -5,6 +5,7 @@ import db from '@/lib/db';
 import { ActionType } from '@/type';
 import { Activity } from '@prisma/client';
 import { getCurrentUserId } from '@/app/data/user';
+import { revalidateTag } from 'next/cache';
 
 export const createActivity = async ({
   title,
@@ -43,6 +44,8 @@ export const createActivity = async ({
     });
 
     if (!newActivity) return { success: false, message: '활동 생성에 실패하였습니다.' };
+
+    revalidateTag('activityList');
 
     return {
       success: true,

--- a/app/action/question.ts
+++ b/app/action/question.ts
@@ -4,7 +4,7 @@ import { ActionType } from '@/type';
 import { Question } from '@prisma/client';
 import { getCurrentUserId } from '@/app/data/user';
 import db from '@/lib/db';
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
 
 export const createQuestion = async ({
   title,
@@ -28,7 +28,7 @@ export const createQuestion = async ({
 
     if (!question) return { success: false, message: '질문 생성에 실패하였습니다.' };
 
-    revalidatePath('/question-list', 'page');
+    revalidateTag('questionList');
 
     return {
       success: true,

--- a/app/data/activity.ts
+++ b/app/data/activity.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { getCurrentUser, getCurrentUserId } from '@/app/data/user';
+import { getCurrentUserId } from '@/app/data/user';
 import db from '@/lib/db';
 import {
   ActivityWithUser,
@@ -63,14 +63,15 @@ export const getActivities = async ({
   location,
   size = 5,
   cursor,
+  tags,
 }: {
   type: 'recent' | 'mostFavorite' | 'tag' | 'mostViewed';
   location?: string;
   size?: number;
   cursor?: string;
+  tags?: string[];
 }): Promise<{ activities: ActivityWithUserAndFavoCount[]; cursorId: string | null }> => {
   try {
-    const currentUser = await getCurrentUser();
     let activities;
 
     const baseQuery = {
@@ -125,22 +126,18 @@ export const getActivities = async ({
         break;
 
       case 'tag':
-        if (!currentUser || !currentUser.tags) {
-          throw new Error('현재 유저가 존재하지 않습니다.');
-        }
-
         activities = await db.activity.findMany({
           ...baseQuery,
           where: location
             ? {
                 location,
                 tags: {
-                  hasSome: currentUser.tags,
+                  hasSome: tags,
                 },
               }
             : {
                 tags: {
-                  hasSome: currentUser.tags,
+                  hasSome: tags,
                 },
               },
           orderBy: {


### PR DESCRIPTION
제한적으로 활동, 질문 리스트에만 캐싱 추가해봤습니다.
기존 next.js는 fetch를 기반으로 캐싱을 지원하는데 저희는 prisma로 서버리스 동작을 하는 바람에 해당기능 활용이 안됩니다. 그래서 next.js에서 제공하는 unstable_cache를 사용해봤습니다. 아직 불안정하지만 우선은 이걸로 테스트한번 해보겠습니다.
그리고 캐싱처리를 하다보니 해당 로직에서 auth()사용하는게 제한되는것같아 우선 현재 유저 태그도 페이지에서 전달하는걸로 변경했습니다.