### PR TITLE
위치 기반 기능 react-query 적용

### DIFF
--- a/app/(protected)/(main)/activity-list/_components/activity-slide.tsx
+++ b/app/(protected)/(main)/activity-list/_components/activity-slide.tsx
@@ -10,7 +10,7 @@ import SlideButtonContainer from './slide-button-container';
 export default function ActivitySlide({
   recommendList,
 }: {
-  recommendList: ActivityWithUserAndFavoCount[];
+  recommendList?: ActivityWithUserAndFavoCount[];
 }) {
   const [slideScrollDistance, setSlideScrollDistance] = useState(0);
   const [isPrevDisabled, setIsPrevDisabled] = useState(true);
@@ -43,7 +43,7 @@ export default function ActivitySlide({
 
   useEffect(() => {
     if (slideRef.current) {
-      if (slideRef.current.firstElementChild) {
+      if (slideRef.current.firstElementChild && recommendList) {
         setSlideScrollDistance(
           slideRef.current.firstElementChild.scrollWidth / recommendList.length,
         );
@@ -61,7 +61,22 @@ export default function ActivitySlide({
         slide.removeEventListener('scroll', settingSlide);
       }
     };
-  }, [settingSlide]);
+  }, [settingSlide, recommendList]);
+
+  if (!recommendList || recommendList.length === 0) {
+    return (
+      <div className="relative">
+        <div className="px-5">
+          <div>
+            <p className="text-lg font-semibold">근처의 길라를 찾을 수 없어요!</p>
+          </div>
+          <div>
+            <ActivityCardSkeleton />
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="relative">
@@ -73,7 +88,7 @@ export default function ActivitySlide({
           isPrevDisabled={isPrevDisabled}
         />
       )}
-      {recommendList[0] ? (
+      {recommendList[0] && (
         <div className="overflow-x-scroll [&::-webkit-scrollbar]:hidden h-full" ref={slideRef}>
           <ul className="flex gap-4 w-fit">
             {recommendList.map((item, index) => (
@@ -85,15 +100,6 @@ export default function ActivitySlide({
               </li>
             ))}
           </ul>
-        </div>
-      ) : (
-        <div className="px-5">
-          <div>
-            <p className="text-lg font-semibold">근처의 길라를 찾을 수 없어요!</p>
-          </div>
-          <div>
-            <ActivityCardSkeleton />
-          </div>
         </div>
       )}
     </div>

--- a/app/(protected)/(main)/activity-list/page.tsx
+++ b/app/(protected)/(main)/activity-list/page.tsx
@@ -4,6 +4,7 @@ import MainCarousel from '@/app/(protected)/(main)/_components/main-carousel';
 import ActivityContainer from '@/app/(protected)/(main)/activity-list/_components/activity-container';
 import Link from 'next/link';
 import PlusDiv from '@/components/common/plus-div';
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
 
 export default async function Page({
   searchParams: { sort, location },
@@ -11,6 +12,11 @@ export default async function Page({
   searchParams: { sort: Sort; location: string };
 }) {
   const { activities, cursorId } = await getActivities({ type: sort, location, size: 5 });
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery({
+    queryKey: ['activityByLocation'],
+  });
 
   return (
     <main className="relative">
@@ -18,12 +24,14 @@ export default async function Page({
         <h1 className="px-4 pt-4 text-xl font-semibold">현재 주목받는 길라들</h1>
         <MainCarousel />
       </div>
-      <ActivityContainer
-        activities={activities}
-        cursorId={cursorId}
-        sort={sort}
-        location={location}
-      />
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <ActivityContainer
+          activities={activities}
+          cursorId={cursorId}
+          sort={sort}
+          location={location}
+        />
+      </HydrationBoundary>
       <div className="fixed w-8 bottom-24 right-[20px] z-50 tall:right-[calc(50vw-380px)]">
         <Link href="/dashboard/my-activity/create">
           <PlusDiv />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { ourFileRouter } from '@/app/api/uploadthing/core';
 import Toaster from '@/components/ui/sonner';
 import GilaLayout from './_components/gila-layout';
 import './globals.css';
+import Providers from './utils/providers';
 
 export const metadata: Metadata = {
   title: 'Gila',
@@ -19,14 +20,16 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className="relative tall:bg-gray_100">
-        <NextSSRPlugin routerConfig={extractRouterConfig(ourFileRouter)} />
-        <Toaster />
-        <div className="w-full tall:my-0 tall:mx-auto tall:flex justify-center">
-          <GilaLayout />
-          <div className="max-w-[420px] mx-auto tall:mx-0 tall:bg-white_light tall:w-[420px] pt-16 tall:pt-0">
-            {children}
+        <Providers>
+          <NextSSRPlugin routerConfig={extractRouterConfig(ourFileRouter)} />
+          <Toaster />
+          <div className="w-full tall:my-0 tall:mx-auto tall:flex justify-center">
+            <GilaLayout />
+            <div className="max-w-[420px] mx-auto tall:mx-0 tall:bg-white_light tall:w-[420px] pt-16 tall:pt-0">
+              {children}
+            </div>
           </div>
-        </div>
+        </Providers>
       </body>
     </html>
   );

--- a/app/utils/providers.tsx
+++ b/app/utils/providers.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { useState } from 'react';
+
+function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}
+
+export default Providers;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@auth/prisma-adapter": "^2.4.1",
-        "@faker-js/faker": "^8.4.1",
         "@hookform/resolvers": "^3.9.0",
         "@prisma/client": "^5.17.0",
         "@radix-ui/react-accordion": "^1.2.0",
@@ -23,6 +22,8 @@
         "@radix-ui/react-select": "^2.1.1",
         "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.0",
+        "@tanstack/react-query": "^5.56.2",
+        "@tanstack/react-query-devtools": "^5.56.2",
         "@types/bcryptjs": "^2.4.6",
         "@types/nodemailer": "^6.4.15",
         "@uploadthing/react": "^6.7.2",
@@ -493,20 +494,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@faker-js/faker": {
-      "version": "8.4.1",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fakerjs"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-        "npm": ">=6.14.13"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -1746,6 +1733,55 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.56.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.56.2.tgz",
+      "integrity": "sha512-gor0RI3/R5rVV3gXfddh1MM+hgl0Z4G7tj6Xxpq6p2I03NGPaJ8dITY9Gz05zYYb/EJq9vPas/T4wn9EaDPd4Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.56.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.56.1.tgz",
+      "integrity": "sha512-xnp9jq/9dHfSCDmmf+A5DjbIjYqbnnUL2ToqlaaviUQGRTapXQ8J+GxusYUu1IG0vZMaWdiVUA4HRGGZYAUU+A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.56.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.56.2.tgz",
+      "integrity": "sha512-SR0GzHVo6yzhN72pnRhkEFRAHMsUo5ZPzAxfTMvUxFIDVS6W9LYUp6nXW3fcHVdg0ZJl8opSH85jqahvm6DSVg==",
+      "dependencies": {
+        "@tanstack/query-core": "5.56.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.56.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.56.2.tgz",
+      "integrity": "sha512-7nINJtRZZVwhTTyDdMIcSaXo+EHMLYJu1S2e6FskvvD5prx87LlAXXWZDfU24Qm4HjshEtM5lS3HIOszNGblcw==",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.56.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.56.2",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/bcryptjs": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.4.1",
-    "@faker-js/faker": "^8.4.1",
     "@hookform/resolvers": "^3.9.0",
     "@prisma/client": "^5.17.0",
     "@radix-ui/react-accordion": "^1.2.0",
@@ -24,6 +23,8 @@
     "@radix-ui/react-select": "^2.1.1",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
+    "@tanstack/react-query": "^5.56.2",
+    "@tanstack/react-query-devtools": "^5.56.2",
     "@types/bcryptjs": "^2.4.6",
     "@types/nodemailer": "^6.4.15",
     "@uploadthing/react": "^6.7.2",


### PR DESCRIPTION
next에서 서버 캐시를 사용해서 해당 기능을 구현할수가 없어서 클라이언트에서 캐싱을 도와주는 react-query적용을 시켰습니다.
아무래도 현재 접속 위치와 비교해서 동작하는 로직이다보니 서버에서 관리할 방법이 전혀 없네요
![스크린샷 2024-09-14 오전 2 30 02](https://github.com/user-attachments/assets/2e7c5bf2-8938-4427-80a4-63a39814eddc)
우선 key값이랑 enabled값 설정해서 초기에 로케이션 값이 설정되면 리액트 쿼리 동작하면서 캐싱합니다.
옆에 network보시면 `/activity-list`로 요청가는게 보이는데 다른 페이지갔다가 돌아오면
![스크린샷 2024-09-14 오전 2 30 21](https://github.com/user-attachments/assets/10647c01-b0cb-42fc-b8e5-d370a0d4eb5d)
서버에서 데이터 요청안하고 캐싱된 데이터 사용합니다. 계속 요청가는건 접속 위치 API랑 카카오맵때문에 발생하는건데 이건 어쩔수 없네요.
그리고 SSR이라서 hydration해야한다고 해서 prefetching도 추가해놨습니다.