### PR TITLE
회원가입 form 로직 수정 및 폼 스키마 분리

### DIFF
--- a/app/(auth)/sign-in/_components/login-form.tsx
+++ b/app/(auth)/sign-in/_components/login-form.tsx
@@ -12,7 +12,7 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { useState, useTransition } from 'react';
+import { useTransition } from 'react';
 import { LoginSchemaType } from '@/type';
 import { toast } from 'sonner';
 import { login } from '@/app/action/user';
@@ -23,7 +23,6 @@ import PrimaryCTAButton from '@/components/common/primary-CTA-button';
 import { loginFields } from '@/constants/form-schema';
 
 export default function LoginForm() {
-  const [isVisible, setIsVisible] = useState(false);
   const router = useRouter();
 
   const [isPending, startTransition] = useTransition();
@@ -36,10 +35,6 @@ export default function LoginForm() {
     },
     mode: 'onBlur',
   });
-
-  const handleVisibility = () => {
-    setIsVisible(!isVisible);
-  };
 
   function onSubmit(values: LoginSchemaType) {
     startTransition(async () => {
@@ -67,8 +62,6 @@ export default function LoginForm() {
                 <FormControl>
                   {field.type === 'password' ? (
                     <PasswordInput
-                      type={isVisible ? 'text' : 'password'}
-                      handleToggle={handleVisibility}
                       placeholder={field.placeholder}
                       className={cn(
                         form.getFieldState(field.name as keyof LoginSchemaType).error &&

--- a/app/(auth)/sign-in/_components/login-form.tsx
+++ b/app/(auth)/sign-in/_components/login-form.tsx
@@ -20,16 +20,7 @@ import { useRouter } from 'next/navigation';
 import PasswordInput from '@/components/ui/password-input';
 import { cn } from '@/lib/utils';
 import PrimaryCTAButton from '@/components/common/primary-CTA-button';
-
-const loginFields = [
-  { name: 'email', label: '이메일', placeholder: '이메일을 입력해 주세요', type: 'text' },
-  {
-    name: 'password',
-    label: '비밀번호',
-    placeholder: '비밀번호를 입력해 주세요',
-    type: 'password',
-  },
-];
+import { loginFields } from '@/constants/form-schema';
 
 export default function LoginForm() {
   const [isVisible, setIsVisible] = useState(false);

--- a/app/(auth)/sign-up/_components/register-form.tsx
+++ b/app/(auth)/sign-up/_components/register-form.tsx
@@ -22,29 +22,7 @@ import { cn } from '@/lib/utils';
 import PrimaryCTAButton from '@/components/common/primary-CTA-button';
 import { sendEmail } from '@/app/action/mail';
 import { Button } from '@/components/ui/button';
-
-const registerFields = [
-  { name: 'nickname', label: '닉네임', placeholder: '닉네임을 입력해 주세요', type: 'text' },
-  { name: 'email', label: '이메일', placeholder: '이메일을 입력해 주세요', type: 'text' },
-  {
-    name: 'emailCheck',
-    label: '인증번호입력',
-    placeholder: '인증번호를 입력해 주세요',
-    type: 'text',
-  },
-  {
-    name: 'password',
-    label: '비밀번호',
-    placeholder: '비밀번호를 입력해 주세요',
-    type: 'password',
-  },
-  {
-    name: 'confirmPassword',
-    label: '비밀번호 확인',
-    placeholder: '비밀번호를 한 번 더 입력해 주세요',
-    type: 'password',
-  },
-];
+import { registerFields } from '@/constants/form-schema';
 
 export default function RegisterForm() {
   const [isCheck, setIsCheck] = useState(false);

--- a/app/(auth)/sign-up/_components/register-form.tsx
+++ b/app/(auth)/sign-up/_components/register-form.tsx
@@ -99,7 +99,7 @@ export default function RegisterForm() {
     });
   }
 
-  const handleVisibility = (name: string) => {
+  const toggleVisibility = (name: string) => {
     if (name === 'password') {
       setIsVisible(!isVisible);
     } else {
@@ -107,76 +107,159 @@ export default function RegisterForm() {
     }
   };
 
-  const settingPasswordInputType = (name: string) => {
-    if (name === 'password') return isVisible;
-    return isConfirmVisible;
-  };
-
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="w-full">
         <h1 className="mb-2 text-xl font-semibold">회원가입</h1>
-        {registerFields.map((field) => (
-          <FormField
-            key={field.name}
-            control={form.control}
-            name={field.name as keyof RegisterSchemaType}
-            render={({ field: controllerField }) => (
-              <FormItem className="relative">
-                <FormLabel>{field.label}</FormLabel>
-                <FormControl className="text-base">
-                  {field.type === 'password' ? (
-                    <PasswordInput
-                      type={settingPasswordInputType(field.name) ? 'text' : 'password'}
-                      handleToggle={() => handleVisibility(field.name)}
-                      placeholder={field.placeholder}
-                      autoComplete="off"
-                      className={cn(
-                        form.getFieldState(field.name as keyof RegisterSchemaType).error &&
-                          'bg-red bg-opacity-10 border-red',
-                        'border border-gray-300',
-                      )}
-                      {...controllerField}
-                    />
-                  ) : (
-                    <div className="relative">
-                      <Input
-                        disabled={field.name === 'emailCheck' && !isCheck}
-                        type={field.type}
-                        placeholder={field.placeholder}
-                        className={cn(
-                          form.getFieldState(field.name as keyof RegisterSchemaType).error &&
-                            'bg-red bg-opacity-10 border-red',
-                          'border border-gray-300',
-                        )}
-                        {...controllerField}
-                      />
-                      {(field.name === 'email' || field.name === 'emailCheck') && (
-                        <Button
-                          type="button"
-                          className="text-white absolute top-1/2 right-1 -translate-y-1/2 w-10 h-8"
-                          onClick={field.name === 'email' ? requsetKey : checkKey}
-                          disabled={
-                            field.name === 'email'
-                              ? isCheck ||
-                                !form.getValues('email') ||
-                                !!form.getFieldState('email').invalid
-                              : !isCheck
-                          }
-                        >
-                          {field.name === 'email' ? '인증' : '확인'}
-                        </Button>
-                      )}
-                    </div>
-                  )}
-                </FormControl>
-                <div className="h-5">
-                  <FormMessage className="text-xs" />
+        <FormField
+          control={form.control}
+          name={registerFields[0].name as keyof RegisterSchemaType}
+          render={({ field: controllerField }) => (
+            <FormItem className="relative">
+              <FormLabel>{registerFields[0].label}</FormLabel>
+              <FormControl className="text-base">
+                <div className="relative">
+                  <Input
+                    type={registerFields[0].type}
+                    placeholder={registerFields[0].placeholder}
+                    className={cn(
+                      form.getFieldState(registerFields[0].name as keyof RegisterSchemaType)
+                        .error && 'bg-red bg-opacity-10 border-red',
+                      'border border-gray-300',
+                    )}
+                    {...controllerField}
+                  />
                 </div>
-              </FormItem>
-            )}
-          />
-        ))}
+              </FormControl>
+              <div className="h-5">
+                <FormMessage className="text-xs" />
+              </div>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name={registerFields[1].name as keyof RegisterSchemaType}
+          render={({ field: controllerField }) => (
+            <FormItem className="relative">
+              <FormLabel>{registerFields[1].label}</FormLabel>
+              <FormControl className="text-base">
+                <div className="relative">
+                  <Input
+                    type={registerFields[1].type}
+                    placeholder={registerFields[1].placeholder}
+                    className={cn(
+                      form.getFieldState(registerFields[1].name as keyof RegisterSchemaType)
+                        .error && 'bg-red bg-opacity-10 border-red',
+                      'border border-gray-300',
+                    )}
+                    {...controllerField}
+                  />
+                  <Button
+                    type="button"
+                    className="text-white absolute top-1/2 right-1 -translate-y-1/2 w-10 h-8"
+                    onClick={requsetKey}
+                    disabled={
+                      isCheck || !form.getValues('email') || !!form.getFieldState('email').invalid
+                    }
+                  >
+                    인증
+                  </Button>
+                </div>
+              </FormControl>
+              <div className="h-5">
+                <FormMessage className="text-xs" />
+              </div>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name={registerFields[2].name as keyof RegisterSchemaType}
+          render={({ field: controllerField }) => (
+            <FormItem className="relative">
+              <FormLabel>{registerFields[2].label}</FormLabel>
+              <FormControl className="text-base">
+                <div className="relative">
+                  <Input
+                    disabled={!isCheck}
+                    type={registerFields[2].type}
+                    placeholder={registerFields[2].placeholder}
+                    className={cn(
+                      form.getFieldState(registerFields[2].name as keyof RegisterSchemaType)
+                        .error && 'bg-red bg-opacity-10 border-red',
+                      'border border-gray-300',
+                    )}
+                    {...controllerField}
+                  />
+                  <Button
+                    type="button"
+                    className="text-white absolute top-1/2 right-1 -translate-y-1/2 w-10 h-8"
+                    onClick={checkKey}
+                    disabled={!isCheck}
+                  >
+                    확인
+                  </Button>
+                </div>
+              </FormControl>
+              <div className="h-5">
+                <FormMessage className="text-xs" />
+              </div>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name={registerFields[3].name as keyof RegisterSchemaType}
+          render={({ field: controllerField }) => (
+            <FormItem className="relative">
+              <FormLabel>{registerFields[3].label}</FormLabel>
+              <FormControl className="text-base">
+                <PasswordInput
+                  type={isVisible ? 'text' : 'password'}
+                  handleToggle={() => toggleVisibility(registerFields[3].name)}
+                  placeholder={registerFields[3].placeholder}
+                  autoComplete="off"
+                  className={cn(
+                    form.getFieldState(registerFields[3].name as keyof RegisterSchemaType).error &&
+                      'bg-red bg-opacity-10 border-red',
+                    'border border-gray-300',
+                  )}
+                  {...controllerField}
+                />
+              </FormControl>
+              <div className="h-5">
+                <FormMessage className="text-xs" />
+              </div>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name={registerFields[4].name as keyof RegisterSchemaType}
+          render={({ field: controllerField }) => (
+            <FormItem className="relative">
+              <FormLabel>{registerFields[4].label}</FormLabel>
+              <FormControl className="text-base">
+                <PasswordInput
+                  type={isConfirmVisible ? 'text' : 'password'}
+                  handleToggle={() => toggleVisibility(registerFields[4].name)}
+                  placeholder={registerFields[4].placeholder}
+                  autoComplete="off"
+                  className={cn(
+                    form.getFieldState(registerFields[4].name as keyof RegisterSchemaType).error &&
+                      'bg-red bg-opacity-10 border-red',
+                    'border border-gray-300',
+                  )}
+                  {...controllerField}
+                />
+              </FormControl>
+              <div className="h-5">
+                <FormMessage className="text-xs" />
+              </div>
+            </FormItem>
+          )}
+        />
         <PrimaryCTAButton
           text="회원가입"
           disabled={isPending || !form.formState.isValid || !validEmail}

--- a/app/(auth)/sign-up/_components/register-form.tsx
+++ b/app/(auth)/sign-up/_components/register-form.tsx
@@ -28,8 +28,6 @@ export default function RegisterForm() {
   const [isCheck, setIsCheck] = useState(false);
   const [emailKey, setEmailKey] = useState('');
   const [validEmail, setValidEmail] = useState(false);
-  const [isVisible, setIsVisible] = useState(false);
-  const [isConfirmVisible, setIsConfirmVisible] = useState(false);
   const router = useRouter();
 
   const [isPending, startTransition] = useTransition();
@@ -76,14 +74,6 @@ export default function RegisterForm() {
       router.replace('/sign-in');
     });
   }
-
-  const toggleVisibility = (name: string) => {
-    if (name === 'password') {
-      setIsVisible(!isVisible);
-    } else {
-      setIsConfirmVisible(!isConfirmVisible);
-    }
-  };
 
   return (
     <Form {...form}>
@@ -194,8 +184,6 @@ export default function RegisterForm() {
               <FormLabel>{registerFields[3].label}</FormLabel>
               <FormControl className="text-base">
                 <PasswordInput
-                  type={isVisible ? 'text' : 'password'}
-                  handleToggle={() => toggleVisibility(registerFields[3].name)}
                   placeholder={registerFields[3].placeholder}
                   autoComplete="off"
                   className={cn(
@@ -220,8 +208,6 @@ export default function RegisterForm() {
               <FormLabel>{registerFields[4].label}</FormLabel>
               <FormControl className="text-base">
                 <PasswordInput
-                  type={isConfirmVisible ? 'text' : 'password'}
-                  handleToggle={() => toggleVisibility(registerFields[4].name)}
                   placeholder={registerFields[4].placeholder}
                   autoComplete="off"
                   className={cn(

--- a/app/(protected)/(detail)/question/[questionId]/_components/answer-edit-form.tsx
+++ b/app/(protected)/(detail)/question/[questionId]/_components/answer-edit-form.tsx
@@ -13,6 +13,7 @@ import {
 import Spinner from '@/components/ui/spinner';
 import { Textarea } from '@/components/ui/textarea';
 import UploadButton from '@/components/upload-button';
+import { EditFormFields } from '@/constants/form-schema';
 import { AnswerWithUser } from '@/type';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { FileImage, X } from 'lucide-react';
@@ -27,13 +28,6 @@ interface Props {
   answerId: string;
   handleEditAnswer: () => void;
 }
-
-const FormFields = {
-  name: 'content',
-  label: '수정하기',
-  placeholder: '답변을 입력해 주세요',
-  type: 'textarea',
-};
 
 const FormSchema = z.object({
   content: z
@@ -107,7 +101,7 @@ export default function AnswerEditForm({ answerId, defaultValue, handleEditAnswe
                   />
                 </div>
 
-                <FormLabel className="text-sm">{FormFields.label}</FormLabel>
+                <FormLabel className="text-sm">{EditFormFields.label}</FormLabel>
                 {loading && (
                   <div className="flex items-center justify-center">
                     <Spinner />
@@ -126,7 +120,11 @@ export default function AnswerEditForm({ answerId, defaultValue, handleEditAnswe
                   </div>
                 )}
                 <FormControl>
-                  <Textarea placeholder={FormFields.placeholder} {...field} className="text-xs" />
+                  <Textarea
+                    placeholder={EditFormFields.placeholder}
+                    {...field}
+                    className="text-xs"
+                  />
                 </FormControl>
                 <div className="absolute -bottom-6">
                   <FormMessage className="text-xs text-red" />

--- a/app/(protected)/(detail)/question/[questionId]/_components/answer-form.tsx
+++ b/app/(protected)/(detail)/question/[questionId]/_components/answer-form.tsx
@@ -13,6 +13,7 @@ import {
 import Spinner from '@/components/ui/spinner';
 import { Textarea } from '@/components/ui/textarea';
 import UploadButton from '@/components/upload-button';
+import { AnswerFormFields } from '@/constants/form-schema';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { FileImage, X } from 'lucide-react';
 import Image from 'next/image';
@@ -20,13 +21,6 @@ import { useState, useTransition } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
-
-const FormFields = {
-  name: 'content',
-  label: '답변하기',
-  placeholder: '답변을 입력해 주세요',
-  type: 'textarea',
-};
 
 const FormSchema = z.object({
   content: z
@@ -98,7 +92,7 @@ export default function AnswerForm({ questionId }: { questionId: string }) {
                     CustomButton={customButton}
                   />
                 </div>
-                <FormLabel className="pl-1 text-sm">{FormFields.label}</FormLabel>
+                <FormLabel className="pl-1 text-sm">{AnswerFormFields.label}</FormLabel>
                 {loading && (
                   <div className="flex items-center justify-center">
                     <Spinner />
@@ -116,7 +110,11 @@ export default function AnswerForm({ questionId }: { questionId: string }) {
                   </div>
                 )}
                 <FormControl>
-                  <Textarea placeholder={FormFields.placeholder} {...field} className="text-xs" />
+                  <Textarea
+                    placeholder={AnswerFormFields.placeholder}
+                    {...field}
+                    className="text-xs"
+                  />
                 </FormControl>
                 <div className="absolute -bottom-6">
                   <FormMessage className="text-xs text-red" />

--- a/app/(protected)/(main)/question-list/_components/question-form.tsx
+++ b/app/(protected)/(main)/question-list/_components/question-form.tsx
@@ -12,27 +12,7 @@ import { toast } from 'sonner';
 import { useTransition } from 'react';
 import LocationSelectDrawer from '@/components/location-select-drawer';
 import PrimaryCTAButton from '@/components/common/primary-CTA-button';
-
-const FormFields = [
-  {
-    name: 'location',
-    label: '장소',
-    placeholder: '장소를 입력해 주세요',
-    type: 'text',
-  },
-  {
-    name: 'title',
-    label: '제목',
-    placeholder: '제목을 입력해 주세요',
-    type: 'text',
-  },
-  {
-    name: 'content',
-    label: '내용',
-    placeholder: '내용을 입력해 주세요',
-    type: 'textarea',
-  },
-];
+import { QuestionFormFields } from '@/constants/form-schema';
 
 const FormSchema = z.object({
   title: z
@@ -88,7 +68,7 @@ export default function QuestionForm() {
             name="location"
             render={({ field: { onChange } }) => (
               <FormItem>
-                <FormLabel className="text-base">{FormFields[0].label}</FormLabel>
+                <FormLabel className="text-base">{QuestionFormFields[0].label}</FormLabel>
                 <FormControl>
                   <LocationSelectDrawer onChange={onChange} />
                 </FormControl>
@@ -100,11 +80,11 @@ export default function QuestionForm() {
             name="title"
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="text-base">{FormFields[1].label}</FormLabel>
+                <FormLabel className="text-base">{QuestionFormFields[1].label}</FormLabel>
                 <FormControl>
                   <Input
-                    type={FormFields[1].type}
-                    placeholder={FormFields[1].placeholder}
+                    type={QuestionFormFields[1].type}
+                    placeholder={QuestionFormFields[1].placeholder}
                     {...field}
                     className="text-sm"
                   />
@@ -117,10 +97,10 @@ export default function QuestionForm() {
             name="content"
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="text-base">{FormFields[2].label}</FormLabel>
+                <FormLabel className="text-base">{QuestionFormFields[2].label}</FormLabel>
                 <FormControl>
                   <Textarea
-                    placeholder={FormFields[2].placeholder}
+                    placeholder={QuestionFormFields[2].placeholder}
                     {...field}
                     className="text-sm"
                   />

--- a/app/(protected)/(user)/dashboard/my-question/_components/my-question-edit-form.tsx
+++ b/app/(protected)/(user)/dashboard/my-question/_components/my-question-edit-form.tsx
@@ -18,6 +18,7 @@ import { editQuestion } from '@/app/action/question';
 import { toast } from 'sonner';
 import { useTransition } from 'react';
 import LocationSelectDrawer from '@/components/location-select-drawer';
+import { QuestionFormFields } from '@/constants/form-schema';
 
 interface Props {
   questionId: string;
@@ -26,27 +27,6 @@ interface Props {
   questionLocation: string;
   setEditModalOpen: () => void;
 }
-
-const FormFields = [
-  {
-    name: 'location',
-    label: '장소',
-    placeholder: '장소를 입력해 주세요',
-    type: 'text',
-  },
-  {
-    name: 'title',
-    label: '제목',
-    placeholder: '제목을 입력해 주세요',
-    type: 'text',
-  },
-  {
-    name: 'content',
-    label: '내용',
-    placeholder: '내용을 입력해 주세요',
-    type: 'textarea',
-  },
-];
 
 const FormSchema = z.object({
   title: z
@@ -110,7 +90,7 @@ export default function MyQuestionEditForm({
             name="location"
             render={({ field: { onChange } }) => (
               <FormItem>
-                <FormLabel className="text-sm">{FormFields[0].label}</FormLabel>
+                <FormLabel className="text-sm">{QuestionFormFields[0].label}</FormLabel>
                 <FormControl>
                   <div className="relative">
                     <LocationSelectDrawer onChange={onChange} defaultLocation={questionLocation} />
@@ -127,11 +107,11 @@ export default function MyQuestionEditForm({
             name="title"
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="text-sm">{FormFields[1].label}</FormLabel>
+                <FormLabel className="text-sm">{QuestionFormFields[1].label}</FormLabel>
                 <FormControl>
                   <Input
-                    type={FormFields[1].type}
-                    placeholder={FormFields[1].placeholder}
+                    type={QuestionFormFields[1].type}
+                    placeholder={QuestionFormFields[1].placeholder}
                     {...field}
                     className="text-xs"
                   />
@@ -147,10 +127,10 @@ export default function MyQuestionEditForm({
             name="content"
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="text-sm">{FormFields[2].label}</FormLabel>
+                <FormLabel className="text-sm">{QuestionFormFields[2].label}</FormLabel>
                 <FormControl>
                   <Textarea
-                    placeholder={FormFields[2].placeholder}
+                    placeholder={QuestionFormFields[2].placeholder}
                     {...field}
                     className="text-xs"
                   />

--- a/app/(protected)/(user)/dashboard/my-question/_components/my-question-form.tsx
+++ b/app/(protected)/(user)/dashboard/my-question/_components/my-question-form.tsx
@@ -18,27 +18,7 @@ import { createQuestion } from '@/app/action/question';
 import { toast } from 'sonner';
 import { useTransition } from 'react';
 import LocationSelectDrawer from '@/components/location-select-drawer';
-
-const FormFields = [
-  {
-    name: 'location',
-    label: '장소',
-    placeholder: '장소를 입력해 주세요',
-    type: 'text',
-  },
-  {
-    name: 'title',
-    label: '제목',
-    placeholder: '제목을 입력해 주세요',
-    type: 'text',
-  },
-  {
-    name: 'content',
-    label: '내용',
-    placeholder: '내용을 입력해 주세요',
-    type: 'textarea',
-  },
-];
+import { QuestionFormFields } from '@/constants/form-schema';
 
 const FormSchema = z.object({
   title: z
@@ -95,7 +75,7 @@ export default function MyQuestionForm({ toggleModal }: { toggleModal: () => voi
             name="location"
             render={({ field: { onChange } }) => (
               <FormItem>
-                <FormLabel className="text-sm">{FormFields[0].label}</FormLabel>
+                <FormLabel className="text-sm">{QuestionFormFields[0].label}</FormLabel>
                 <FormControl>
                   <LocationSelectDrawer onChange={onChange} />
                 </FormControl>
@@ -110,11 +90,11 @@ export default function MyQuestionForm({ toggleModal }: { toggleModal: () => voi
             name="title"
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="text-sm">{FormFields[1].label}</FormLabel>
+                <FormLabel className="text-sm">{QuestionFormFields[1].label}</FormLabel>
                 <FormControl>
                   <Input
-                    type={FormFields[1].type}
-                    placeholder={FormFields[1].placeholder}
+                    type={QuestionFormFields[1].type}
+                    placeholder={QuestionFormFields[1].placeholder}
                     {...field}
                     className="text-xs"
                   />
@@ -130,10 +110,10 @@ export default function MyQuestionForm({ toggleModal }: { toggleModal: () => voi
             name="content"
             render={({ field }) => (
               <FormItem>
-                <FormLabel className="text-sm">{FormFields[2].label}</FormLabel>
+                <FormLabel className="text-sm">{QuestionFormFields[2].label}</FormLabel>
                 <FormControl>
                   <Textarea
-                    placeholder={FormFields[2].placeholder}
+                    placeholder={QuestionFormFields[2].placeholder}
                     {...field}
                     className="text-xs"
                   />

--- a/components/ui/password-input.tsx
+++ b/components/ui/password-input.tsx
@@ -1,40 +1,40 @@
 'use client';
 
-import { forwardRef } from 'react';
+import { forwardRef, useState } from 'react';
 import { EyeIcon, EyeOffIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input, InputProps } from '@/components/ui/input';
 
-interface Props extends InputProps {
-  handleToggle: () => void;
-}
+interface Props extends InputProps {}
 
-const PasswordInput = forwardRef<HTMLInputElement, Props>(
-  ({ className, handleToggle, ...props }, ref) => {
-    const disabled = props.value === '' || props.value === undefined || props.disabled;
+const PasswordInput = forwardRef<HTMLInputElement, Props>(({ className, ...props }, ref) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const disabled = props.value === '' || props.value === undefined || props.disabled;
+  const toggleInput = () => {
+    setIsVisible(!isVisible);
+  };
 
-    return (
-      <div className="relative">
-        <Input className={className} ref={ref} {...props} />
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={handleToggle}
-          disabled={disabled}
-          tabIndex={-1}
-          className="absolute top-0.5 right-0"
-        >
-          {props.type === 'password' && !disabled ? (
-            <EyeIcon aria-hidden="true" tabIndex={-1} color="#A4A1AA" size={20} />
-          ) : (
-            <EyeOffIcon aria-hidden="true" tabIndex={-1} color="#A4A1AA" size={20} />
-          )}
-        </Button>
-      </div>
-    );
-  },
-);
+  return (
+    <div className="relative">
+      <Input className={className} ref={ref} {...props} type={isVisible ? 'text' : 'password'} />
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={toggleInput}
+        disabled={disabled}
+        tabIndex={-1}
+        className="absolute top-0.5 right-0"
+      >
+        {props.type === 'password' && !disabled ? (
+          <EyeIcon aria-hidden="true" tabIndex={-1} color="#A4A1AA" size={20} />
+        ) : (
+          <EyeOffIcon aria-hidden="true" tabIndex={-1} color="#A4A1AA" size={20} />
+        )}
+      </Button>
+    </div>
+  );
+});
 
 PasswordInput.displayName = 'PasswordInput';
 

--- a/constants/form-schema.ts
+++ b/constants/form-schema.ts
@@ -1,0 +1,67 @@
+export const registerFields = [
+  { name: 'nickname', label: '닉네임', placeholder: '닉네임을 입력해 주세요', type: 'text' },
+  { name: 'email', label: '이메일', placeholder: '이메일을 입력해 주세요', type: 'text' },
+  {
+    name: 'emailCheck',
+    label: '인증번호입력',
+    placeholder: '인증번호를 입력해 주세요',
+    type: 'text',
+  },
+  {
+    name: 'password',
+    label: '비밀번호',
+    placeholder: '비밀번호를 입력해 주세요',
+    type: 'password',
+  },
+  {
+    name: 'confirmPassword',
+    label: '비밀번호 확인',
+    placeholder: '비밀번호를 한 번 더 입력해 주세요',
+    type: 'password',
+  },
+];
+
+export const loginFields = [
+  { name: 'email', label: '이메일', placeholder: '이메일을 입력해 주세요', type: 'text' },
+  {
+    name: 'password',
+    label: '비밀번호',
+    placeholder: '비밀번호를 입력해 주세요',
+    type: 'password',
+  },
+];
+
+export const EditFormFields = {
+  name: 'content',
+  label: '수정하기',
+  placeholder: '답변을 입력해 주세요',
+  type: 'textarea',
+};
+
+export const AnswerFormFields = {
+  name: 'content',
+  label: '답변하기',
+  placeholder: '답변을 입력해 주세요',
+  type: 'textarea',
+};
+
+export const QuestionFormFields = [
+  {
+    name: 'location',
+    label: '장소',
+    placeholder: '장소를 입력해 주세요',
+    type: 'text',
+  },
+  {
+    name: 'title',
+    label: '제목',
+    placeholder: '제목을 입력해 주세요',
+    type: 'text',
+  },
+  {
+    name: 'content',
+    label: '내용',
+    placeholder: '내용을 입력해 주세요',
+    type: 'textarea',
+  },
+];


### PR DESCRIPTION
기존 로직에서 회원가입 form을 map을 통해서 렌더링하다보니 너무 삼항 연산자랑 조건부가 많이 붙어서
전부 없애고 각 인풋마다 하나씩 별도로 설정해놨습니다. 공통 컴포넌트로 묶고 싶은데 각 조건이 다르고 props도 넘겨줘야해서 일단 이렇게 수정해두겟습니다
추가적으로 formField schema 별도로 파일 분리했습니다.