### PR TITLE
비로그인 유저 기능 적용

### DIFF
--- a/app/(protected)/(detail)/activity/[activityId]/_components/detail-content.tsx
+++ b/app/(protected)/(detail)/activity/[activityId]/_components/detail-content.tsx
@@ -4,15 +4,17 @@ import DetailDescription from '@/app/(protected)/(detail)/activity/[activityId]/
 import DetailCarousel from '@/app/(protected)/(detail)/activity/[activityId]/_components/detail-carousel';
 import AuthorInfo from '@/app/(protected)/(detail)/activity/[activityId]/_components/author-info';
 import { getActivityById } from '@/app/data/activity';
+import { getSessionUserData } from '@/app/data/user';
 
 export default async function DetailContent({ activityId }: { activityId: string }) {
   const activity = await getActivityById(activityId);
+  const session = await getSessionUserData();
 
   return (
     <div>
       <DetailCarousel thumbnails={activity.thumbnails} />
       <div className="flex flex-col gap-6 m-4 pb-20 tall:pb-0">
-        <DetailTitle activityDetail={activity} />
+        <DetailTitle activityDetail={activity} session={session?.id} />
         <DetailDescription description={activity.description} locations={activity.location} />
         <AuthorInfo ownerId={activity.userId} />
       </div>

--- a/app/(protected)/(detail)/activity/[activityId]/_components/detail-title.tsx
+++ b/app/(protected)/(detail)/activity/[activityId]/_components/detail-title.tsx
@@ -11,11 +11,14 @@ import { increaseActivityCount } from '@/app/action/activity';
 import SharePopover from '@/app/(protected)/(detail)/activity/[activityId]/_components/share-popover';
 import formatDateRange from '@/utils/formatDateRange';
 import { ActivityWithUserAndFavorite } from '@/type';
+import toastLoginMessage from '@/utils/toastLoginMessage';
 
 export default function DetailTitle({
   activityDetail,
+  session,
 }: {
   activityDetail: ActivityWithUserAndFavorite;
+  session?: string;
 }) {
   const [favorite, setFavorite] = useState(activityDetail.isFavorite);
   const [viewCount, setViewCount] = useState(activityDetail.views);
@@ -65,7 +68,10 @@ export default function DetailTitle({
           ))}
         </div>
         <div className="flex items-center gap-4">
-          <div onClick={toggleActivityLike} className="cursor-pointer">
+          <div
+            onClick={session ? toggleActivityLike : toastLoginMessage}
+            className="cursor-pointer"
+          >
             {favorite ? <Heart size={20} color="#FF4242" fill="#FF4242" /> : <Heart size={20} />}
           </div>
           <SharePopover activityId={activityDetail.id} shareImage={activityDetail.thumbnails[0]} />

--- a/app/(protected)/(detail)/activity/[activityId]/_components/promise-request-form.tsx
+++ b/app/(protected)/(detail)/activity/[activityId]/_components/promise-request-form.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import REQUEST_STATUS from '@/constants/request';
 import { ActivityWithRequest } from '@/type';
 import formatDateRange from '@/utils/formatDateRange';
+import toastLoginMessage from '@/utils/toastLoginMessage';
 import { useEffect, useState, useTransition } from 'react';
 import { toast } from 'sonner';
 
@@ -14,7 +15,7 @@ export default function PromiseRequestForm({
   currentUser,
 }: {
   activity: ActivityWithRequest;
-  currentUser: string;
+  currentUser?: string;
 }) {
   const { startDate, endDate, id, maximumCount, activityRequests } = activity;
   const [isPending, startTransition] = useTransition();
@@ -55,10 +56,10 @@ export default function PromiseRequestForm({
             <Button
               type="button"
               className="px-4 py-2 text-sm font-semibold text-white border border-none rounded-md bg-primary hover:bg-primary_dark"
-              onClick={applyActivity}
+              onClick={currentUser ? applyActivity : toastLoginMessage}
               disabled={isPending || isDisabled}
             >
-              {buttonStatus}
+              {currentUser ? buttonStatus : '로그인후 신청 가능'}
             </Button>
           )}
         </>

--- a/app/(protected)/(detail)/activity/[activityId]/_components/request-container.tsx
+++ b/app/(protected)/(detail)/activity/[activityId]/_components/request-container.tsx
@@ -4,7 +4,7 @@ import PromiseRequestForm from './promise-request-form';
 
 export default async function RequestContainer({ activityId }: { activityId: string }) {
   const activity = await getActivityById(activityId);
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
 
-  return <PromiseRequestForm activity={activity} currentUser={id} />;
+  return <PromiseRequestForm activity={activity} currentUser={session?.id} />;
 }

--- a/app/(protected)/(detail)/question/[questionId]/_components/answer-list-container.tsx
+++ b/app/(protected)/(detail)/question/[questionId]/_components/answer-list-container.tsx
@@ -5,14 +5,14 @@ import AnswerList from './answer-list';
 
 export default async function AnswerListContainer({ questionId }: { questionId: string }) {
   const questionDetail = await getQuestionById({ questionId, answerTake: 10 });
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
   if (!questionDetail) return <div>없음</div>;
 
   return (
     <AnswerList
       answers={questionDetail.answers}
       totalCount={questionDetail._count.answers}
-      userId={id}
+      userId={session?.id}
       answerCursorId={questionDetail.answerCursorId}
       questionId={questionDetail.id}
     />

--- a/app/(protected)/(detail)/question/[questionId]/_components/answer-list.tsx
+++ b/app/(protected)/(detail)/question/[questionId]/_components/answer-list.tsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect, useState, useTransition } from 'react';
 interface Props {
   answers: AnswerWithUser[];
   totalCount: number;
-  userId: string;
+  userId?: string;
   answerCursorId: string | null;
   questionId: string;
 }

--- a/app/(protected)/(detail)/question/[questionId]/page.tsx
+++ b/app/(protected)/(detail)/question/[questionId]/page.tsx
@@ -7,6 +7,8 @@ import AnswerForm from './_components/answer-form';
 import QuestionDetailSkeleton from './_components/question-detail-skeleton';
 import AnswerListContainer from './_components/answer-list-container';
 import AnswerListSkeleton from './_components/answer-list-skeleton';
+import { getSessionUserData } from '@/app/data/user';
+import LoginLinkArea from '@/components/loginLink-area';
 
 interface Params {
   questionId: string;
@@ -14,6 +16,7 @@ interface Params {
 
 export default async function Page({ params }: { params: Params }) {
   const questionDetail = await getQuestionById({ questionId: params.questionId, answerTake: 10 });
+  const session = await getSessionUserData();
   if (!questionDetail) return <div>없음</div>;
   return (
     <div className="p-4 flex flex-col gap-4">
@@ -24,7 +27,10 @@ export default async function Page({ params }: { params: Params }) {
         <AnswerListContainer questionId={params.questionId} />
       </Suspense>
       <Separator className="bg-gray_300" />
-      <AnswerForm />
+      <div className="relative">
+        {!session && <LoginLinkArea />}
+        <AnswerForm />
+      </div>
     </div>
   );
 }

--- a/app/(protected)/(detail)/question/[questionId]/page.tsx
+++ b/app/(protected)/(detail)/question/[questionId]/page.tsx
@@ -2,13 +2,13 @@
 import { getQuestionById } from '@/app/data/question';
 import { Separator } from '@/components/ui/separator';
 import { Suspense } from 'react';
+import { getSessionUserData } from '@/app/data/user';
+import LoginLinkArea from '@/components/loginLink-area';
 import QuestionDetail from './_components/question-detail';
 import AnswerForm from './_components/answer-form';
 import QuestionDetailSkeleton from './_components/question-detail-skeleton';
 import AnswerListContainer from './_components/answer-list-container';
 import AnswerListSkeleton from './_components/answer-list-skeleton';
-import { getSessionUserData } from '@/app/data/user';
-import LoginLinkArea from '@/components/loginLink-area';
 
 interface Params {
   questionId: string;

--- a/app/(protected)/(main)/question-list/page.tsx
+++ b/app/(protected)/(main)/question-list/page.tsx
@@ -3,6 +3,8 @@ import { QuestionSort } from '@/type';
 import { Suspense } from 'react';
 import QuestionContainer from './_components/question-container';
 import QuestionListSkeleton from './_components/question-list-skeleton';
+import { getSessionUserData } from '@/app/data/user';
+import LoginLinkArea from '@/components/loginLink-area';
 
 export default async function Page({
   searchParams,
@@ -10,6 +12,7 @@ export default async function Page({
   searchParams: { sort: QuestionSort; location: string };
 }) {
   const { sort, location } = searchParams;
+  const session = await getSessionUserData();
 
   return (
     <main className="w-full">
@@ -17,7 +20,10 @@ export default async function Page({
         <h1 className="text-2xl font-semibold">
           <span className="text-3xl font-bold text-primary">길라</span>에게 바로 물어보세요!
         </h1>
-        <QuestionForm />
+        <div className="relative w-full">
+          {!session && <LoginLinkArea />}
+          <QuestionForm />
+        </div>
       </div>
       <div className="flex flex-col items-center w-full gap-2 p-5">
         <Suspense fallback={<QuestionListSkeleton />}>

--- a/app/(protected)/(main)/question-list/page.tsx
+++ b/app/(protected)/(main)/question-list/page.tsx
@@ -1,10 +1,10 @@
 import QuestionForm from '@/app/(protected)/(main)/question-list/_components/question-form';
 import { QuestionSort } from '@/type';
 import { Suspense } from 'react';
-import QuestionContainer from './_components/question-container';
-import QuestionListSkeleton from './_components/question-list-skeleton';
 import { getSessionUserData } from '@/app/data/user';
 import LoginLinkArea from '@/components/loginLink-area';
+import QuestionContainer from './_components/question-container';
+import QuestionListSkeleton from './_components/question-list-skeleton';
 
 export default async function Page({
   searchParams,

--- a/app/(protected)/(user)/dashboard/my-activity/page.tsx
+++ b/app/(protected)/(user)/dashboard/my-activity/page.tsx
@@ -6,16 +6,18 @@ import MyActivityContainer from './_components/my-activity-container';
 import MyActivitySkeleton from './_components/my-activity-skeleton';
 
 export default async function Page() {
-  const { name } = await getSessionUserData();
+  const session = await getSessionUserData();
 
   return (
     <main className="p-5">
       <div className="flex items-center justify-between w-full pb-5">
         <div>
           <h1 className="text-2xl font-bold">
-            <span className="text-3xl text-primary">{name}</span>님의 길라 활동
+            <span className="text-3xl text-primary">{session?.name}</span>님의 길라 활동
           </h1>
-          <p className="text-base font-medium">여기서 {name}님만의 길라 활동을 관리하세요!</p>
+          <p className="text-base font-medium">
+            여기서 {session?.name}님만의 길라 활동을 관리하세요!
+          </p>
         </div>
         <div>
           <Link href="/dashboard/my-activity/create" className="relative z-10">

--- a/app/(protected)/(user)/dashboard/my-chat/page.tsx
+++ b/app/(protected)/(user)/dashboard/my-chat/page.tsx
@@ -4,14 +4,14 @@ import ChatContainer from './_components/chat-container';
 import WishListSkeleton from '../wishlist/_components/wishList-skeleton';
 
 export default async function Page() {
-  const { name } = await getSessionUserData();
+  const session = await getSessionUserData();
 
   return (
     <main className="p-5">
       <div className="flex items-center justify-between w-full pb-5">
         <div>
           <h1 className="text-2xl font-bold">
-            <span className="text-3xl text-primary">{name}</span>님이 등록한 채팅
+            <span className="text-3xl text-primary">{session?.name}</span>님이 등록한 채팅
           </h1>
           <p className="text-base font-medium">등록한 활동의 참가자들과 소통해보세요!</p>
         </div>

--- a/app/(protected)/(user)/dashboard/my-question/page.tsx
+++ b/app/(protected)/(user)/dashboard/my-question/page.tsx
@@ -5,13 +5,13 @@ import MyQuestionContainer from './_components/my-question-container';
 import MyQuestionSkeleton from './_components/my-question-skeleton';
 
 export default async function Page() {
-  const { name } = await getSessionUserData();
+  const session = await getSessionUserData();
 
   return (
     <div className="p-5">
       <div className="flex justify-between w-full mb-5">
         <h1 className="text-2xl font-bold">
-          <span className="text-3xl text-primary">{name}</span>님의 질문
+          <span className="text-3xl text-primary">{session?.name}</span>님의 질문
         </h1>
         <MyQuestionCreateModal />
       </div>

--- a/app/(protected)/(user)/dashboard/promise-list/page.tsx
+++ b/app/(protected)/(user)/dashboard/promise-list/page.tsx
@@ -4,12 +4,12 @@ import PromiseContainer from './_components/promise-container';
 import MyActivitySkeleton from '../my-activity/_components/my-activity-skeleton';
 
 export default async function Page() {
-  const { name } = await getSessionUserData();
+  const session = await getSessionUserData();
 
   return (
     <main className="p-5 flex flex-col gap-4">
       <h1 className="w-full text-2xl font-bold">
-        <span className="text-3xl text-primary">{name}</span>님이 신청한 활동
+        <span className="text-3xl text-primary">{session?.name}</span>님이 신청한 활동
         <p className="text-base font-medium">신청이 수락되면 참가자들과 소통할 수 있어요!</p>
       </h1>
       <Suspense fallback={<MyActivitySkeleton />}>

--- a/app/(protected)/(user)/dashboard/promised-list/page.tsx
+++ b/app/(protected)/(user)/dashboard/promised-list/page.tsx
@@ -4,12 +4,12 @@ import PromisedContainer from './_components/promised-container';
 import PromisedSkeleton from './_components/promised-skeleton';
 
 export default async function Page() {
-  const { name } = await getSessionUserData();
+  const session = await getSessionUserData();
 
   return (
     <main className="p-5 flex flex-col gap-4">
       <h1 className="w-full text-2xl font-bold">
-        <span className="text-3xl text-primary">{name}</span>님과 함께하고 싶대요!
+        <span className="text-3xl text-primary">{session?.name}</span>님과 함께하고 싶대요!
       </h1>
       <Suspense fallback={<PromisedSkeleton />}>
         <PromisedContainer />

--- a/app/(protected)/(user)/dashboard/wishlist/page.tsx
+++ b/app/(protected)/(user)/dashboard/wishlist/page.tsx
@@ -4,12 +4,12 @@ import WishListSkeleton from './_components/wishList-skeleton';
 import WishListContainer from './_components/wishlist-container';
 
 export default async function Page() {
-  const { name } = await getSessionUserData();
+  const session = await getSessionUserData();
 
   return (
     <main className="p-5 flex flex-col gap-4">
       <h1 className="text-2xl font-bold">
-        <span className="text-3xl text-primary">{name}</span>님이 저장한 활동
+        <span className="text-3xl text-primary">{session?.name}</span>님이 저장한 활동
       </h1>
       <Suspense fallback={<WishListSkeleton />}>
         <WishListContainer />

--- a/app/(protected)/(user)/profile/edit/page.tsx
+++ b/app/(protected)/(user)/profile/edit/page.tsx
@@ -6,7 +6,8 @@ import ProfileSkeleton from '../_components/profile-skeleton';
 import EditProfileContainer from './_components/edit-profile-container';
 
 export default async function Page() {
-  const { id, name, image } = await getSessionUserData();
+  const session = await getSessionUserData();
+  if (!session) return <div>인증이 필요합니다.</div>;
 
   return (
     <main className="p-5">
@@ -14,12 +15,12 @@ export default async function Page() {
         <Card className="shadow-md">
           <CardHeader className="flex flex-col gap-5">
             <CardTitle className="font-bold text-center">
-              <span className="text-3xl text-primary">{name}</span>님의 개인정보
+              <span className="text-3xl text-primary">{session.name}</span>님의 개인정보
             </CardTitle>
-            <EditImageForm userImg={image ?? '/default-profile-image.png'} />
+            <EditImageForm userImg={session.image ?? '/default-profile-image.png'} />
           </CardHeader>
           <CardContent>
-            <EditProfileContainer id={id} />
+            <EditProfileContainer id={session.id} />
           </CardContent>
         </Card>
       </Suspense>

--- a/app/(protected)/(user)/profile/page.tsx
+++ b/app/(protected)/(user)/profile/page.tsx
@@ -6,7 +6,8 @@ import ProfileContainer from './_components/profile-container';
 import ProfileSkeleton from './_components/profile-skeleton';
 
 export default async function Page() {
-  const { id, name, image } = await getSessionUserData();
+  const session = await getSessionUserData();
+  if (!session) return <div>인증이 필요합니다.</div>;
 
   return (
     <main className="p-5">
@@ -14,12 +15,12 @@ export default async function Page() {
         <Card className="shadow-md">
           <CardHeader className="flex flex-col gap-5">
             <CardTitle className="font-bold text-center">
-              <span className="text-3xl text-primary">{name}</span>님의 프로필
+              <span className="text-3xl text-primary">{session.name}</span>님의 프로필
             </CardTitle>
-            <ProfileImage image={image} />
+            <ProfileImage image={session.image} />
           </CardHeader>
           <CardContent>
-            <ProfileContainer id={id} />
+            <ProfileContainer id={session.id} />
           </CardContent>
         </Card>
       </Suspense>

--- a/app/(protected)/chat/[channel]/page.tsx
+++ b/app/(protected)/chat/[channel]/page.tsx
@@ -6,6 +6,7 @@ export default async function Page({ params }: { params: { channel: string } }) 
   const user = await getCurrentUser();
   const activity = await getChannelById(params.channel);
 
+  if (!user) return <div>인증이 필요합니다.</div>;
   return (
     <ChatPage
       channel={params.channel}

--- a/app/(public)/_components/landing-hero-section.tsx
+++ b/app/(public)/_components/landing-hero-section.tsx
@@ -1,6 +1,11 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
 export default function LandingHeroSection() {
+  const router = useRouter();
   return (
     <section className="flex flex-col items-center justify-center gap-3 pt-20 bg-white_light">
       <h1 className="text-4xl font-bold text-center">
@@ -10,6 +15,13 @@ export default function LandingHeroSection() {
       <div className="w-[220px] h-[100px] relative">
         <Image fill src="/GilaName.png" alt="text-main-logo" style={{ objectFit: 'cover' }} />
       </div>
+      <Button
+        className="text-sm font-semibold text-white border border-none rounded-md bg-primary hover:bg-primary_dark"
+        onClick={() => router.push('/activity-list')}
+        size="lg"
+      >
+        바로가기
+      </Button>
       <div className="w-full h-40 relative">
         <Image
           src="/LandingBackground.jpg"

--- a/app/action/activity-request.ts
+++ b/app/action/activity-request.ts
@@ -9,12 +9,14 @@ import { getSessionUserData } from '@/app/data/user';
 export const createActivityRequest = async (
   activityId: string,
 ): Promise<ActionType<ActivityRequest>> => {
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
+
   try {
     const existingRequest = await db.activityRequest.findUnique({
       where: {
         requestUserId_activityId: {
-          requestUserId: id,
+          requestUserId: session.id,
           activityId,
         },
       },
@@ -30,13 +32,13 @@ export const createActivityRequest = async (
       },
     });
 
-    if (myActivity?.userId === id) {
+    if (myActivity?.userId === session.id) {
       return { success: false, message: '본인의 활동은 신청할 수 없습니다.' };
     }
 
     const activityRequest = await db.activityRequest.create({
       data: {
-        requestUserId: id,
+        requestUserId: session.id,
         activityId,
       },
     });

--- a/app/action/activity.ts
+++ b/app/action/activity.ts
@@ -5,6 +5,7 @@ import db from '@/lib/db';
 import { ActionType } from '@/type';
 import { Activity } from '@prisma/client';
 import { getSessionUserData } from '@/app/data/user';
+import { revalidatePath } from 'next/cache';
 
 export const createActivity = async ({
   title,
@@ -44,6 +45,8 @@ export const createActivity = async ({
     });
 
     if (!newActivity) return { success: false, message: '활동 생성에 실패하였습니다.' };
+
+    revalidatePath('/dashboard/my-activity', 'page');
 
     return {
       success: true,

--- a/app/action/activity.ts
+++ b/app/action/activity.ts
@@ -26,11 +26,12 @@ export const createActivity = async ({
   maximumCount: number;
 }): Promise<ActionType<Activity>> => {
   try {
-    const { id } = await getSessionUserData();
+    const session = await getSessionUserData();
+    if (!session) throw new Error('인증이 필요합니다.');
 
     const newActivity = await db.activity.create({
       data: {
-        userId: id,
+        userId: session.id,
         title,
         description,
         startDate,
@@ -75,12 +76,14 @@ export const editActivity = async ({
   location: string;
   maximumCount: number;
 }): Promise<ActionType<Activity>> => {
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
+
   try {
     const updatedActivity = await db.activity.update({
       where: { id: activityId },
       data: {
-        userId: id,
+        userId: session.id,
         title,
         description,
         startDate,

--- a/app/action/answer.ts
+++ b/app/action/answer.ts
@@ -15,11 +15,12 @@ export const createAnswer = async ({
   content: string;
   images?: string[];
 }): Promise<ActionType<Answer>> => {
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
   try {
     const newAnswer = await db.answer.create({
       data: {
-        userId: id,
+        userId: session.id,
         questionId,
         content,
         images,

--- a/app/action/favorite.ts
+++ b/app/action/favorite.ts
@@ -6,12 +6,13 @@ import { ActionType } from '@/type';
 import { Favorite } from '@prisma/client';
 
 const toggleFavorite = async (activityId: string): Promise<ActionType<Favorite>> => {
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
   try {
+    if (!session) throw new Error('인증되지 않은 유저입니다.');
     const existingFavorite = await db.favorite.findFirst({
       where: {
         activityId,
-        userId: id,
+        userId: session.id,
       },
     });
 
@@ -27,7 +28,7 @@ const toggleFavorite = async (activityId: string): Promise<ActionType<Favorite>>
 
     const newFavorite = await db.favorite.create({
       data: {
-        userId: id,
+        userId: session.id,
         activityId,
       },
     });

--- a/app/action/favorite.ts
+++ b/app/action/favorite.ts
@@ -7,8 +7,8 @@ import { Favorite } from '@prisma/client';
 
 const toggleFavorite = async (activityId: string): Promise<ActionType<Favorite>> => {
   const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
   try {
-    if (!session) throw new Error('인증되지 않은 유저입니다.');
     const existingFavorite = await db.favorite.findFirst({
       where: {
         activityId,

--- a/app/action/mail.ts
+++ b/app/action/mail.ts
@@ -36,23 +36,30 @@ export const sendEmail = async (email: string) => {
 };
 
 export const requestMail = async (activity: ActivityWithUserAndFavorite) => {
-  const { name } = await getSessionUserData();
-  const date = formatDateRange({
-    startDateString: activity.startDate,
-    endDateString: activity.endDate,
-  });
-  const owner = await getUserProfileWithIntroducedInfos(activity.userId);
-  await transporter.sendMail({
-    from: process.env.NEXT_PUBLIC_EMAIL_ADDRESS,
-    to: owner.user.email,
-    subject: `"${activity.title}" 활동 신청 요청이 있습니다.`,
-    html: `<h1>${activity.title}</h1>
-    <h2>세부 일정: ${date}</h2>
-    <p>신청자: ${name}</p>
-    <a href="${process.env.NEXT_PUBLIC_BASE_URL}/dashboard/promised-list">확인하러 가기</a>
-    `,
-  });
-  return { message: '길라에게 메일을 전송했습니다.' };
+  const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
+  try {
+    const date = formatDateRange({
+      startDateString: activity.startDate,
+      endDateString: activity.endDate,
+    });
+    const owner = await getUserProfileWithIntroducedInfos(activity.userId);
+    await transporter.sendMail({
+      from: process.env.NEXT_PUBLIC_EMAIL_ADDRESS,
+      to: owner.user.email,
+      subject: `"${activity.title}" 활동 신청 요청이 있습니다.`,
+      html: `<h1>${activity.title}</h1>
+      <h2>세부 일정: ${date}</h2>
+      <p>신청자: ${session.name}</p>
+      <a href="${process.env.NEXT_PUBLIC_BASE_URL}/dashboard/promised-list">확인하러 가기</a>
+      `,
+    });
+    return { message: '길라에게 메일을 전송했습니다.' };
+  } catch (error) {
+    return {
+      message: '메일 전송중 에러가 발생하였습니다.',
+    };
+  }
 };
 
 export const responseMail = async (
@@ -60,21 +67,28 @@ export const responseMail = async (
   requsetUser: User,
   result: 'approve' | 'reject',
 ) => {
-  const { name } = await getSessionUserData();
-  const date = formatDateRange({
-    startDateString: activity.startDate,
-    endDateString: activity.endDate,
-  });
-  await transporter.sendMail({
-    from: process.env.NEXT_PUBLIC_EMAIL_ADDRESS,
-    to: requsetUser.email,
-    subject: `"${activity.title}" 활동 신청 결과입니다.`,
-    html: `<h1>${activity.title}</h1>
+  const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
+  try {
+    const date = formatDateRange({
+      startDateString: activity.startDate,
+      endDateString: activity.endDate,
+    });
+    await transporter.sendMail({
+      from: process.env.NEXT_PUBLIC_EMAIL_ADDRESS,
+      to: requsetUser.email,
+      subject: `"${activity.title}" 활동 신청 결과입니다.`,
+      html: `<h1>${activity.title}</h1>
     <h2>세부 일정 : ${date}</h2>
-    <p>길라 : ${name}</p>
+    <p>길라 : ${session.name}</p>
     <p>결과 : ${result === 'approve' ? '수락됨' : '거절됨'}</p>
     <a href="${process.env.NEXT_PUBLIC_BASE_URL}/dashboard/promise-list">확인하러 가기</a>
     `,
-  });
-  return { message: '길라에게 메일을 전송했습니다.' };
+    });
+    return { message: '길라에게 메일을 전송했습니다.' };
+  } catch (error) {
+    return {
+      message: '메일 전송중 에러가 발생하였습니다.',
+    };
+  }
 };

--- a/app/action/question.ts
+++ b/app/action/question.ts
@@ -15,11 +15,13 @@ export const createQuestion = async ({
   content: string;
   location: string;
 }): Promise<ActionType<Question>> => {
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
+
   try {
     const question = await db.question.create({
       data: {
-        userId: id,
+        userId: session.id,
         title,
         content,
         location,

--- a/app/action/review.ts
+++ b/app/action/review.ts
@@ -17,13 +17,14 @@ const createReview = async ({
     return { success: false, message: '점수는 100을 초과할 수 없습니다.' };
   }
 
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
 
   try {
     const existingReview = await db.review.findUnique({
       where: {
         userId_activityId: {
-          userId: id,
+          userId: session.id,
           activityId,
         },
       },
@@ -35,7 +36,7 @@ const createReview = async ({
 
     const newReview = await db.review.create({
       data: {
-        userId: id,
+        userId: session.id,
         rating,
         activityId,
       },

--- a/app/action/user.ts
+++ b/app/action/user.ts
@@ -126,12 +126,13 @@ export const logout = async (): Promise<ActionType<null>> => {
 };
 
 export const editNickname = async (newNickname: string): Promise<ActionType<User>> => {
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
   try {
     const checkNickName = await findUserByNickname(newNickname);
     if (checkNickName) return { success: false, message: '이미 사용중인 닉네임입니다.' };
     const updatedUser = await db.user.update({
-      where: { id },
+      where: { id: session.id },
       data: { nickname: newNickname },
     });
 
@@ -151,10 +152,12 @@ export const editNickname = async (newNickname: string): Promise<ActionType<User
 };
 
 export const editPassword = async (newPassword: string): Promise<ActionType<User>> => {
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
+
   try {
     const updatedUser = await db.user.update({
-      where: { id },
+      where: { id: session.id },
       data: { password: newPassword },
     });
 
@@ -174,11 +177,12 @@ export const editPassword = async (newPassword: string): Promise<ActionType<User
 };
 
 export const editTags = async (tags: string[]): Promise<ActionType<User>> => {
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
 
   try {
     const updatedUser = await db.user.update({
-      where: { id },
+      where: { id: session.id },
       data: { tags },
     });
 
@@ -195,11 +199,12 @@ export const editTags = async (tags: string[]): Promise<ActionType<User>> => {
 };
 
 export const editImage = async (url: string): Promise<ActionType<User>> => {
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
 
   try {
     const updatedUser = await db.user.update({
-      where: { id },
+      where: { id: session.id },
       data: { image: url },
     });
 
@@ -219,11 +224,12 @@ export const editImage = async (url: string): Promise<ActionType<User>> => {
 };
 
 export const setFirstLoginToFalse = async (): Promise<ActionType<null>> => {
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
 
   try {
     const user = await db.user.update({
-      where: { id },
+      where: { id: session.id },
       data: {
         isFirstLogin: false,
       },

--- a/app/api/uploadthing/core.ts
+++ b/app/api/uploadthing/core.ts
@@ -6,8 +6,8 @@ const f = createUploadthing();
 export const ourFileRouter = {
   imageUploader: f({ image: { maxFileSize: '4MB', maxFileCount: 5 } })
     .middleware(async () => {
-      const { id } = await getSessionUserData();
-      return { userId: id };
+      const session = await getSessionUserData();
+      return { userId: session?.id };
     })
     .onUploadComplete(async ({ metadata }) => {
       return { uploadedBy: metadata.userId };

--- a/app/data/activity-request.ts
+++ b/app/data/activity-request.ts
@@ -12,11 +12,12 @@ export const getMySentRequests = async ({
   cursor?: string;
   take?: number;
 }): Promise<{ validRequests: RequestWithActivity[]; cursorId: string | null }> => {
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
   const nowDate = new Date();
   try {
     const requests = await db.activityRequest.findMany({
-      where: { requestUserId: id },
+      where: { requestUserId: session.id },
       include: {
         activity: true,
       },
@@ -56,11 +57,13 @@ export const getMyReceivedRequests = async ({
   take?: number;
 }): Promise<{ requests: RequestWithReqUserAndActivity[]; cursorId: string | null }> => {
   try {
-    const { id } = await getSessionUserData();
+    const session = await getSessionUserData();
+    if (!session) throw new Error('인증이 필요합니다.');
+
     const nowDate = new Date();
 
     const userActivities = await db.activity.findMany({
-      where: { userId: id, endDate: { gte: nowDate } },
+      where: { userId: session.id, endDate: { gte: nowDate } },
       select: {
         activityRequests: {
           where: {

--- a/app/data/activity.ts
+++ b/app/data/activity.ts
@@ -18,17 +18,18 @@ export const getMyActivities = async ({
   take?: number;
 }): Promise<{ activities: ActivityWithFavoriteAndCount[]; cursorId: string | null }> => {
   const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
 
   try {
     const myActivities = await db.activity.findMany({
-      where: { userId: session?.id },
+      where: { userId: session.id },
       include: {
         _count: {
           select: { favorites: true },
         },
         favorites: {
           where: {
-            id: session?.id,
+            id: session.id,
           },
           select: {
             id: true,
@@ -243,6 +244,7 @@ export const getAvailableReviewActivities = async ({
   cursorId: string | null;
 }> => {
   const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
   try {
     const currentDate = new Date();
 
@@ -253,13 +255,13 @@ export const getAvailableReviewActivities = async ({
         },
         activityRequests: {
           some: {
-            requestUserId: session?.id,
+            requestUserId: session.id,
             status: RequestStatus.APPROVE,
           },
         },
         reviews: {
           none: {
-            userId: session?.id,
+            userId: session.id,
           },
         },
       },

--- a/app/data/activity.ts
+++ b/app/data/activity.ts
@@ -225,7 +225,7 @@ export const getActivityById = async (activityId: string): Promise<ActivityWithR
 
     return {
       ...activity,
-      isFavorite: activity.favorites.length > 0,
+      isFavorite: session ? activity.favorites.length > 0 : false,
     };
   } catch (error) {
     throw new Error('활동을 가져오는 중에 에러가 발생하였습니다.');

--- a/app/data/chat.ts
+++ b/app/data/chat.ts
@@ -11,12 +11,13 @@ export const getMyChat = async ({
   cursor?: string;
   take?: number;
 }): Promise<{ activities: ActivityWithUserAndRequest[]; cursorId: string | null }> => {
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
   const nowDate = new Date();
 
   try {
     const myChat = await db.activity.findMany({
-      where: { userId: id, endDate: { gte: nowDate } },
+      where: { userId: session.id, endDate: { gte: nowDate } },
       include: {
         user: {
           select: {

--- a/app/data/favorite.ts
+++ b/app/data/favorite.ts
@@ -11,10 +11,11 @@ const getMyFavorites = async ({
   cursor?: string;
   take?: number;
 }): Promise<{ favorites: FavoriteWithActivity[]; cursorId: string | null }> => {
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
   try {
     const favorites = await db.favorite.findMany({
-      where: { userId: id },
+      where: { userId: session.id },
       include: {
         activity: true,
       },

--- a/app/data/question.ts
+++ b/app/data/question.ts
@@ -93,11 +93,12 @@ export const getMyQuestions = async ({
   answerTake?: number;
   cursor?: string;
 }): Promise<{ questions: QuestionWithUserAndAnswers[]; cursorId: string | null }> => {
-  const { id } = await getSessionUserData();
+  const session = await getSessionUserData();
+  if (!session) throw new Error('인증이 필요합니다.');
 
   const questions = await db.question.findMany({
     where: {
-      userId: id,
+      userId: session.id,
     },
     include: {
       answers: {

--- a/app/data/user.ts
+++ b/app/data/user.ts
@@ -6,7 +6,7 @@ import { User } from '@/type';
 export const getSessionUserData = async () => {
   const session = await auth();
   try {
-    if (!session) throw new Error('현재 로그인되어있지 않습니다.');
+    if (!session) return null;
     if (!session.user) throw new Error('유저 데이터가 없습니다.');
     const { email, name, id, image } = session.user;
     if (!email) throw new Error('존재하지 않는 이메일 입니다.');
@@ -20,12 +20,13 @@ export const getSessionUserData = async () => {
   }
 };
 
-export const getCurrentUser = async (): Promise<User> => {
-  const { email } = await getSessionUserData();
+export const getCurrentUser = async (): Promise<User | null> => {
+  const session = await getSessionUserData();
   try {
+    if (!session) return null;
     const user = await db.user.findUnique({
       where: {
-        email,
+        email: session.email,
       },
       select: {
         id: true,
@@ -36,9 +37,7 @@ export const getCurrentUser = async (): Promise<User> => {
         createdAt: true,
       },
     });
-
     if (!user) throw new Error('유저 정보가 존재하지 않습니다.');
-
     return user;
   } catch (error) {
     throw new Error('유저 정보를 가져오는중에 에러가 발생하였습니다.');
@@ -98,11 +97,12 @@ export const getUserProfileWithIntroducedInfos = async (
   }
 };
 
-export const getIsFirstLogin = async (): Promise<boolean> => {
-  const { id } = await getSessionUserData();
+export const getIsFirstLogin = async (): Promise<boolean | null> => {
+  const session = await getSessionUserData();
   try {
+    if (!session) return null;
     const user = await db.user.findUnique({
-      where: { id },
+      where: { id: session.id },
     });
     if (!user) throw new Error('해당 유저 정보가 존재하지 않습니다.');
 

--- a/components/common/nav-base.tsx
+++ b/components/common/nav-base.tsx
@@ -5,7 +5,7 @@ import NavSideMenu from '@/components/common/nav-sidemenu';
 import { getSessionUserData } from '@/app/data/user';
 
 export default async function NavigationBase({ children }: { children?: ReactNode }) {
-  const { image } = await getSessionUserData();
+  const session = await getSessionUserData();
 
   return (
     <nav className="tall:sticky fixed left-0 top-0 z-50 flex items-center justify-between h-16 p-3 bg-white border-b bg-opacity-95 w-full">
@@ -25,7 +25,7 @@ export default async function NavigationBase({ children }: { children?: ReactNod
       </div>
       {children && <div className="col-span-2">{children}</div>}
       <div className="flex items-center justify-end w-[70px]">
-        <NavSideMenu userAvatar={image} />
+        <NavSideMenu userAvatar={session?.image} />
       </div>
     </nav>
   );

--- a/components/common/nav-base.tsx
+++ b/components/common/nav-base.tsx
@@ -25,7 +25,7 @@ export default async function NavigationBase({ children }: { children?: ReactNod
       </div>
       {children && <div className="col-span-2">{children}</div>}
       <div className="flex items-center justify-end w-[70px]">
-        <NavSideMenu userAvatar={session?.image} />
+        <NavSideMenu userAvatar={session?.image} user={session?.id} />
       </div>
     </nav>
   );

--- a/components/common/nav-sidemenu.tsx
+++ b/components/common/nav-sidemenu.tsx
@@ -8,7 +8,7 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet';
 import Image from 'next/image';
-import { LogOut, Menu } from 'lucide-react';
+import { LogIn, LogOut, Menu } from 'lucide-react';
 import { useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { logout } from '@/app/action/user';
@@ -18,9 +18,10 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 
 interface Props {
   userAvatar: string | null | undefined;
+  user?: string;
 }
 
-export default function NavSideMenu({ userAvatar }: Props) {
+export default function NavSideMenu({ userAvatar, user }: Props) {
   const [isPending, startTrasition] = useTransition();
   const router = useRouter();
 
@@ -74,12 +75,21 @@ export default function NavSideMenu({ userAvatar }: Props) {
           <SideMenuAccordion />
           <button
             disabled={isPending}
-            onClick={Logout}
+            onClick={() => (user ? Logout() : router.push('/sign-in'))}
             type="button"
             className="flex items-center text-black transition-all h-10 rounded-lg w-fit hover:text-primary gap-2"
           >
-            <LogOut width={20} height={20} />
-            <p className="font-semibold text-sm">로그아웃</p>
+            {user ? (
+              <>
+                <LogOut width={20} height={20} />
+                <p className="font-semibold text-sm">로그아웃</p>
+              </>
+            ) : (
+              <>
+                <LogIn width={20} height={20} />
+                <p className="font-semibold text-sm">로그인</p>
+              </>
+            )}
           </button>
         </div>
       </SheetContent>

--- a/components/loginLink-area.tsx
+++ b/components/loginLink-area.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Button } from './ui/button';
+
+export default function LoginLinkArea() {
+  const route = useRouter();
+  const linkLoginPage = () => {
+    route.push('/sign-in');
+  };
+
+  return (
+    <div className="absolute inset-0 bg-gray-200/70 z-10 flex flex-col justify-center items-center rounded-lg">
+      <Button
+        type="button"
+        className="px-4 py-2 text-sm font-semibold text-white border border-none rounded-md bg-primary hover:bg-primary_dark opacity-none z-20"
+        onClick={linkLoginPage}
+      >
+        로그인후 이용하기
+      </Button>
+    </div>
+  );
+}

--- a/components/loginLink-area.tsx
+++ b/components/loginLink-area.tsx
@@ -10,10 +10,10 @@ export default function LoginLinkArea() {
   };
 
   return (
-    <div className="absolute inset-0 bg-gray-200/70 z-10 flex flex-col justify-center items-center rounded-lg">
+    <div className="absolute inset-0 bg-gray-200/70 z-20 flex flex-col justify-center items-center rounded-lg">
       <Button
         type="button"
-        className="px-4 py-2 text-sm font-semibold text-white border border-none rounded-md bg-primary hover:bg-primary_dark opacity-none z-20"
+        className="px-4 py-2 text-sm font-semibold text-white border border-none rounded-md bg-primary hover:bg-primary_dark opacity-none"
         onClick={linkLoginPage}
       >
         로그인후 이용하기

--- a/middleware.ts
+++ b/middleware.ts
@@ -6,11 +6,12 @@ import { auth } from './auth';
 export default auth(async (req) => {
   const { nextUrl } = req;
   const isLoggedIn = !!req.auth;
-
   const isApiAuthRoute = nextUrl.pathname.startsWith(`/${apiAuthPrefix}`);
   const isApiUploadthingRoute = nextUrl.pathname.startsWith(`/${apiUploadThingPrefix}`);
   const isAuthRoute = authRoutes.includes(nextUrl.pathname);
   const isMainPage = nextUrl.pathname === '/';
+  const isDashboardRoute = nextUrl.pathname.startsWith(`/dashboard`);
+  const isProfileRoute = nextUrl.pathname.startsWith(`/profile`);
 
   const isFirst = req.cookies.has('isFirstLogin');
   if (nextUrl.pathname !== '/topic') {
@@ -24,6 +25,10 @@ export default auth(async (req) => {
   }
   if (isApiUploadthingRoute) {
     return;
+  }
+
+  if ((!isLoggedIn && isDashboardRoute) || (!isLoggedIn && isProfileRoute)) {
+    return NextResponse.redirect(new URL('/sign-in', nextUrl));
   }
 
   if (isAuthRoute) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,11 +1,5 @@
 /* eslint-disable consistent-return */
-import {
-  DEFAULT_LOGIN_REDIRECT,
-  apiAuthPrefix,
-  apiUploadThingPrefix,
-  authRoutes,
-  publicRoutes,
-} from '@/routes';
+import { DEFAULT_LOGIN_REDIRECT, apiAuthPrefix, apiUploadThingPrefix, authRoutes } from '@/routes';
 import { NextResponse } from 'next/server';
 import { auth } from './auth';
 
@@ -15,7 +9,6 @@ export default auth(async (req) => {
 
   const isApiAuthRoute = nextUrl.pathname.startsWith(`/${apiAuthPrefix}`);
   const isApiUploadthingRoute = nextUrl.pathname.startsWith(`/${apiUploadThingPrefix}`);
-  const isPublicRoute = publicRoutes.includes(nextUrl.pathname);
   const isAuthRoute = authRoutes.includes(nextUrl.pathname);
   const isMainPage = nextUrl.pathname === '/';
 
@@ -38,10 +31,6 @@ export default auth(async (req) => {
       return NextResponse.redirect(new URL(DEFAULT_LOGIN_REDIRECT, nextUrl));
     }
     return;
-  }
-
-  if (!isLoggedIn && !isPublicRoute) {
-    return NextResponse.redirect(new URL('/sign-in', nextUrl));
   }
 
   if (isLoggedIn && isMainPage) {

--- a/utils/toastLoginMessage.ts
+++ b/utils/toastLoginMessage.ts
@@ -1,0 +1,7 @@
+import { toast } from 'sonner';
+
+const toastLoginMessage = () => {
+  toast.message('로그인후 이용 가능한 기능입니다.');
+};
+
+export default toastLoginMessage;


### PR DESCRIPTION
기존 서비스는 회원 전용 서비스였는데 정보전달과 커뮤니티의 기능을 절반밖에 못한다고 생각합니다.
그래서 기존 회원가입을 해야 확인할 수 있던 컨텐츠들을 비회원일때에도 확인가능하도록 수정했습니다.
활동, 질문 리스트는 동일하게 접근 가능하고 활동 생성, 질문 생성, 활동 신청, 찜 기능은 막아뒀습니다.
활동 신청, 찜은 토스트 메세지로 나타내고 생성하는 것은 아예 로그인 페이지로 보내주고 있습니다.
미들웨어 수정해서 비로그인 유저가 대시보드와 프로필 페이지로 접근하면 로그인 페이지로 리다이렉트 시켜주고 있습니다.